### PR TITLE
Trimmed version

### DIFF
--- a/draft-ietf-opsawg-oam-characterization.html
+++ b/draft-ietf-opsawg-oam-characterization.html
@@ -7,6 +7,7 @@
 <title>Guidelines for Characterizing "OAM"</title>
 <meta content="Carlos Pignataro" name="author">
 <meta content="Adrian Farrel" name="author">
+<meta content="Tal Mizrahi" name="author">
 <meta content='
        
    As the IETF continues to produce and standardize different
@@ -26,22 +27,23 @@
        This document updates RFC 6291 by adding to the guidelines for the
    use of the term "OAM". It does not modify any other part of RFC 6291. 
     ' name="description">
-<meta content="xml2rfc 3.25.0" name="generator">
-<meta content="draft-ietf-opsawg-oam-characterization-04" name="ietf.draft">
+<meta content="xml2rfc 3.28.1" name="generator">
+<meta content="draft-ietf-opsawg-oam-characterization-05" name="ietf.draft">
 <!-- Generator version information:
-  xml2rfc 3.25.0
-    Python 3.9.6
+  xml2rfc 3.28.1
+    Python 3.12.3
     ConfigArgParse 1.7
-    google-i18n-address 3.1.0
+    google-i18n-address 3.1.1
     intervaltree 3.1.0
-    Jinja2 3.1.4
-    lxml 5.3.0
-    platformdirs 4.2.2
+    Jinja2 3.1.6
+    lxml 5.3.1
+    platformdirs 4.3.7
     pycountry 24.6.1
-    PyYAML 6.0.1
+    PyYAML 6.0.2
     requests 2.32.3
-    setuptools 70.2.0
+    setuptools 78.1.0
     wcwidth 0.2.13
+    weasyprint 65.0
 -->
 <link href="draft-ietf-opsawg-oam-characterization.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -418,7 +420,7 @@ hr {
 /* Fix PDF info block run off issue */
 @media print {
   #identifiers dd {
-    float: none;
+    max-width: 100%;
   }
 }
 #identifiers .authors .author {
@@ -1226,11 +1228,11 @@ li > p:last-of-type:only-child {
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">Characterizing OAM</td>
-<td class="right">December 2024</td>
+<td class="right">April 2025</td>
 </tr></thead>
 <tfoot><tr>
-<td class="left">Pignataro &amp; Farrel</td>
-<td class="center">Expires 1 July 2025</td>
+<td class="left">Pignataro, et al.</td>
+<td class="center">Expires 12 October 2025</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1240,18 +1242,18 @@ li > p:last-of-type:only-child {
 <dt class="label-workgroup">Workgroup:</dt>
 <dd class="workgroup">OPS Area Working Group</dd>
 <dt class="label-internet-draft">Internet-Draft:</dt>
-<dd class="internet-draft">draft-ietf-opsawg-oam-characterization-04</dd>
+<dd class="internet-draft">draft-ietf-opsawg-oam-characterization-05</dd>
 <dt class="label-updates">Updates:</dt>
 <dd class="updates">
 <a href="https://www.rfc-editor.org/rfc/rfc6291" class="eref">6291</a> (if approved)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2024-12-28" class="published">28 December 2024</time>
+<time datetime="2025-04-10" class="published">10 April 2025</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Best Current Practice</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2025-07-01">1 July 2025</time></dd>
+<dd class="expires"><time datetime="2025-10-12">12 October 2025</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1261,6 +1263,10 @@ li > p:last-of-type:only-child {
 <div class="author">
       <div class="author-name">A. Farrel</div>
 <div class="org">Old Dog Consulting</div>
+</div>
+<div class="author">
+      <div class="author-name">T. Mizrahi</div>
+<div class="org">Huawei</div>
 </div>
 </dd>
 </dl>
@@ -1303,7 +1309,7 @@ li > p:last-of-type:only-child {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 1 July 2025.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 12 October 2025.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1312,7 +1318,7 @@ li > p:last-of-type:only-child {
 <a href="#name-copyright-notice" class="section-name selfRef">Copyright Notice</a>
         </h2>
 <p id="section-boilerplate.2-1">
-            Copyright (c) 2024 IETF Trust and the persons identified as the
+            Copyright (c) 2025 IETF Trust and the persons identified as the
             document authors. All rights reserved.<a href="#section-boilerplate.2-1" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.2-2">
             This document is subject to BCP 78 and the IETF Trust's Legal
@@ -1347,36 +1353,27 @@ li > p:last-of-type:only-child {
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3">
-            <p id="section-toc.1-1.3.1"><a href="#section-3" class="auto internal xref">3</a>.  <a href="#name-active-passive-hybrid-and-c" class="internal xref">Active, Passive, Hybrid, and Compound OAM</a></p>
+            <p id="section-toc.1-1.3.1"><a href="#section-3" class="auto internal xref">3</a>.  <a href="#name-security-considerations" class="internal xref">Security Considerations</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4">
-            <p id="section-toc.1-1.4.1"><a href="#section-4" class="auto internal xref">4</a>.  <a href="#name-extended-oam-abbreviations" class="internal xref">Extended OAM Abbreviations</a></p>
+            <p id="section-toc.1-1.4.1"><a href="#section-4" class="auto internal xref">4</a>.  <a href="#name-iana-considerations" class="internal xref">IANA Considerations</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5">
-            <p id="section-toc.1-1.5.1"><a href="#section-5" class="auto internal xref">5</a>.  <a href="#name-processing-of-oam-packets-b" class="internal xref">Processing of OAM Packets by Nodes</a></p>
+            <p id="section-toc.1-1.5.1"><a href="#section-5" class="auto internal xref">5</a>.  <a href="#name-acknowledgements" class="internal xref">Acknowledgements</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6">
-            <p id="section-toc.1-1.6.1"><a href="#section-6" class="auto internal xref">6</a>.  <a href="#name-security-considerations" class="internal xref">Security Considerations</a></p>
-</li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7">
-            <p id="section-toc.1-1.7.1"><a href="#section-7" class="auto internal xref">7</a>.  <a href="#name-iana-considerations" class="internal xref">IANA Considerations</a></p>
-</li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8">
-            <p id="section-toc.1-1.8.1"><a href="#section-8" class="auto internal xref">8</a>.  <a href="#name-acknowledgements" class="internal xref">Acknowledgements</a></p>
-</li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9">
-            <p id="section-toc.1-1.9.1"><a href="#section-9" class="auto internal xref">9</a>.  <a href="#name-references" class="internal xref">References</a></p>
+            <p id="section-toc.1-1.6.1"><a href="#section-6" class="auto internal xref">6</a>.  <a href="#name-references" class="internal xref">References</a></p>
 <ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9.2.1">
-                <p id="section-toc.1-1.9.2.1.1"><a href="#section-9.1" class="auto internal xref">9.1</a>.  <a href="#name-normative-references" class="internal xref">Normative References</a></p>
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.1">
+                <p id="section-toc.1-1.6.2.1.1"><a href="#section-6.1" class="auto internal xref">6.1</a>.  <a href="#name-normative-references" class="internal xref">Normative References</a></p>
 </li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9.2.2">
-                <p id="section-toc.1-1.9.2.2.1"><a href="#section-9.2" class="auto internal xref">9.2</a>.  <a href="#name-informative-references" class="internal xref">Informative References</a></p>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.2">
+                <p id="section-toc.1-1.6.2.2.1"><a href="#section-6.2" class="auto internal xref">6.2</a>.  <a href="#name-informative-references" class="internal xref">Informative References</a></p>
 </li>
             </ul>
 </li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10">
-            <p id="section-toc.1-1.10.1"><a href="#appendix-A" class="auto internal xref"></a><a href="#name-authors-addresses" class="internal xref">Authors' Addresses</a></p>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7">
+            <p id="section-toc.1-1.7.1"><a href="#appendix-A" class="auto internal xref"></a><a href="#name-authors-addresses" class="internal xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -1395,15 +1392,8 @@ li > p:last-of-type:only-child {
    their use in future IETF work to achieve consistent and unambiguous
    characterization.<a href="#section-1-2" class="pilcrow">¶</a></p>
 <p id="section-1-3">
-        Additionally, this document recommends avoiding the creation and use of extended abbreviation for the qualifiers of "OAM". For example, the first "O" in "OOAM" could mean out-of-band, overlay, or something else.<a href="#section-1-3" class="pilcrow">¶</a></p>
-<p id="section-1-4">
    This document updates <span>[<a href="#RFC6291" class="cite xref">RFC6291</a>]</span> by adding to the guidelines for the
-   use of the term "OAM". It does not modify any other part of <span>[<a href="#RFC6291" class="cite xref">RFC6291</a>]</span>.<a href="#section-1-4" class="pilcrow">¶</a></p>
-<p id="section-1-5">
-        Note that <span>[<a href="#RFC7799" class="cite xref">RFC7799</a>]</span> defines terms for active and passive
-performance assessments through metrics and methods. That RFC does not
-substantially discuss OAM, and although the concepts are similar, this
-document does not modify the definitions in <span>[<a href="#RFC7799" class="cite xref">RFC7799</a>]</span>.<a href="#section-1-5" class="pilcrow">¶</a></p>
+   use of the term "OAM". It does not modify any other part of <span>[<a href="#RFC6291" class="cite xref">RFC6291</a>]</span>.<a href="#section-1-3" class="pilcrow">¶</a></p>
 </section>
 <div id="band">
 <section id="section-2">
@@ -1413,9 +1403,9 @@ document does not modify the definitions in <span>[<a href="#RFC7799" class="cit
 <p id="section-2-1">
           Historically, the terms "in-band" and "out-of-band" were used extensively in radio communications as well as in telephony signaling <span>[<a href="#RFC4733" class="cite xref">RFC4733</a>]</span>. In both these cases, there is an actual "Band" (i.e., a "Channel" or "Frequency") to be within or outside.<a href="#section-2-1" class="pilcrow">¶</a></p>
 <p id="section-2-2">
-          While those terms, useful in their simplicity, continued to be broadly used to mean "within something" and "outside something", a challenge is presented for IP communications and packet switch networks (PSNs) which do not have a "band" per se, and, in fact, have multiple "somethings" that OAM can be carried within or outside. A frequently encountered case is the use of "in-band" to mean either in-packet or on-path.<a href="#section-2-2" class="pilcrow">¶</a></p>
+          While those terms, useful in their simplicity, continued to be broadly used to mean "within something" and "outside something", a challenge is presented for IP communications and packet-switched networks (PSNs) which do not have a "band" per se, and, in fact, have multiple "somethings" that OAM can be carried within or outside. A frequently encountered case is the use of "in-band" to mean either in-packet or on-path.<a href="#section-2-2" class="pilcrow">¶</a></p>
 <p id="section-2-3">
-          Within the IETF, the terms "in-band" and "out-of-band" cannot be reliably understood consistently and unambiguously. Context-specific redefinitions of these terms cannot be generalized and can be confused by participants from other contexts. More importantly, the terms are not self-defining to any further extent and cannot be understood by someone exposed to them for the first time, since there is no "band" in IP.<a href="#section-2-3" class="pilcrow">¶</a></p>
+          Within the IETF, the terms "in-band" and "out-of-band" cannot be reliably understood consistently and unambiguously. Context-specific definitions of these terms are inconsistent and therefore cannot be generalized. More importantly, the terms are not self-defining to any further extent and cannot be understood by someone exposed to them for the first time, since there is no "band" in IP.<a href="#section-2-3" class="pilcrow">¶</a></p>
 <div id="terms">
 <section id="section-2.1">
         <h3 id="name-terminology-and-guidance">
@@ -1423,12 +1413,10 @@ document does not modify the definitions in <span>[<a href="#RFC7799" class="cit
         </h3>
 <p id="section-2.1-1">
           The guidance in this document is to avoid the terms "in-band" and "out-of-band" when refering to OAM, and instead find finer-granularity descriptive terms.
-          The definitions presented in this document are for use in all future IETF documents that refer
-   to OAM, and the terms "in-band OAM" and "out-of-band OAM" are not to
-   be used in future documents.<a href="#section-2.1-1" class="pilcrow">¶</a></p>
+          Alternative terms and definitions are presented in this document for future use in IETF documents that refer to OAM.<a href="#section-2.1-1" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="dlParallel" id="section-2.1-2">
           <dt id="section-2.1-2.1">Path OAM:</dt>
-          <dd style="margin-left: 1.5em" id="section-2.1-2.2"> OAM in relation to a path.<a href="#section-2.1-2.2" class="pilcrow">¶</a>
+          <dd style="margin-left: 1.5em" id="section-2.1-2.2"> OAM in relation to a path<a href="#section-2.1-2.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt id="section-2.1-2.3"></dt>
@@ -1452,76 +1440,101 @@ document does not modify the definitions in <span>[<a href="#RFC7799" class="cit
             <span>[<a href="#RFC6669" class="cite xref">RFC6669</a>]</span>, Section 2 fourth bullet, gives an example of "Path-Congruent OAM", and further describes that the OAM Packets "share their fate with data packets."<a href="#section-2.1-2.6" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-2.1-2.7">Packet OAM:</dt>
-          <dd style="margin-left: 1.5em" id="section-2.1-2.8"> OAM in relation to a user data packet.<a href="#section-2.1-2.8" class="pilcrow">¶</a>
-</dd>
+<dt id="section-2.1-2.7">Active, Passive, Hybrid, and In-Packet OAM</dt>
+          <dd style="margin-left: 1.5em" id="section-2.1-2.8"></dd>
           <dd class="break"></dd>
 <dt id="section-2.1-2.9"></dt>
           <dd style="margin-left: 1.5em" id="section-2.1-2.10">
-            <span class="break"></span><dl class="dlParallel" id="section-2.1-2.10.1">
-              <dt id="section-2.1-2.10.1.1">In-Packet OAM:</dt>
-              <dd style="margin-left: 1.5em" id="section-2.1-2.10.1.2">
-                <br>The OAM information is carried in the packets that also carry the data traffic. This was sometimes referred to as "in-band".<a href="#section-2.1-2.10.1.2" class="pilcrow">¶</a>
+            <p id="section-2.1-2.10.1"><span>[<a href="#RFC7799" class="cite xref">RFC7799</a>]</span> provides clear definitions for active and passive
+               performance assessment such that the construction of metrics and
+               methods can be described as either "Active" or "Passive".  Even
+               though <span>[<a href="#RFC7799" class="cite xref">RFC7799</a>]</span> does not include the specific terms "Active",
+               "Passive", or "Hybrid" as modifiers of "OAM", the following terms
+               are used in many RFCs and are provided here for clarity.<a href="#section-2.1-2.10.1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlParallel" id="section-2.1-2.10.2">
+              <dt id="section-2.1-2.10.2.1">Active OAM:</dt>
+              <dd style="margin-left: 1.5em" id="section-2.1-2.10.2.2">
+                <br> Depends on dedicated OAM packets.<a href="#section-2.1-2.10.2.2" class="pilcrow">¶</a>
 </dd>
               <dd class="break"></dd>
-<dt id="section-2.1-2.10.1.3">Dedicated-Packet OAM:</dt>
-              <dd style="margin-left: 1.5em" id="section-2.1-2.10.1.4">
-                <br>The OAM information is carried in its own OAM packets, separate from data traffic. This was sometimes referred to as "out-of-band".<a href="#section-2.1-2.10.1.4" class="pilcrow">¶</a>
+<dt id="section-2.1-2.10.2.3">Passive OAM:</dt>
+              <dd style="margin-left: 1.5em" id="section-2.1-2.10.2.4">
+                <br> Depends solely on the observation of one
+      or more existing data packet streams and does not use dedicated OAM packets.<a href="#section-2.1-2.10.2.4" class="pilcrow">¶</a>
+</dd>
+              <dd class="break"></dd>
+<dt id="section-2.1-2.10.2.5">Hybrid OAM:</dt>
+              <dd style="margin-left: 1.5em" id="section-2.1-2.10.2.6">
+                <br> Uses instrumentation or modification of data packets themselves. <span>[<a href="#RFC9341" class="cite xref">RFC9341</a>]</span> and <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span> are examples labeled "Hybrid OAM" under this definition.<a href="#section-2.1-2.10.2.6" class="pilcrow">¶</a>
 </dd>
             <dd class="break"></dd>
 </dl>
 </dd>
           <dd class="break"></dd>
 <dt id="section-2.1-2.11"></dt>
-          <dd style="margin-left: 1.5em" id="section-2.1-2.12">
-  The MPLS echo request/reply messages <span>[<a href="#RFC8029" class="cite xref">RFC8029</a>]</span> are an example of "Dedicated-Packet OAM", since they are described as "An MPLS echo request/reply is a (possibly MPLS-labeled) IPv4 or IPv6 UDP packet".<a href="#section-2.1-2.12" class="pilcrow">¶</a>
+          <dd style="margin-left: 1.5em" id="section-2.1-2.12">This document defines the term In-Packet OAM, which is a special case of Hybrid OAM:<a href="#section-2.1-2.12" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt id="section-2.1-2.13"></dt>
-          <dd style="margin-left: 1.5em" id="section-2.1-2.14">In situ OAM <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span> is an example of "In-Packet OAM", given that it: '...records OAM information
-  within the packet while the packet traverses a particular network
-  domain.  The term "in situ" refers to the fact that the OAM data is
-  added to the data packets rather than being sent within packets
-  specifically dedicated to OAM.'<a href="#section-2.1-2.14" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-2.1-2.15"></dt>
-          <dd style="margin-left: 1.5em" id="section-2.1-2.16">
-  Initially, "in situ OAM" <span>[<a href="#IETF96-In-Band-OAM" class="cite xref">IETF96-In-Band-OAM</a>]</span> was also referred to as "In-band OAM", but was renamed due to the overloaded meaning of "in-band OAM". Further, <span>[<a href="#RFC9232" class="cite xref">RFC9232</a>]</span> also intertwines the terms "in-band" with "in situ", though <span>[<a href="#I-D.song-opsawg-ifit-framework" class="cite xref">I-D.song-opsawg-ifit-framework</a>]</span> settled on using "in Situ". Other similar uses, including <span>[<a href="#P4-INT-2.1" class="cite xref">P4-INT-2.1</a>]</span> and <span>[<a href="#I-D.kumar-ippm-ifa" class="cite xref">I-D.kumar-ippm-ifa</a>]</span>, still use variations of "in-band", "in band", or "inband".<a href="#section-2.1-2.16" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd><dt id="section-2.1-2.17">Packet Forwarding Treatment OAM:</dt>
-          <dd style="margin-left: 1.5em" id="section-2.1-2.18"> OAM in relation to the forwarding treatment of user data packets, as for example QoS treatment.<a href="#section-2.1-2.18" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-2.1-2.19"></dt>
-          <dd style="margin-left: 1.5em" id="section-2.1-2.20">
-            <span class="break"></span><dl class="dlParallel" id="section-2.1-2.20.1">
-              <dt id="section-2.1-2.20.1.1">Equal-Forwarding-Treatment OAM:</dt>
-              <dd style="margin-left: 1.5em" id="section-2.1-2.20.1.2">
-                <br>The OAM packets receive the same forwarding (e.g., QoS) treatment as user data packets. This was sometimes referred to as "in-band".<a href="#section-2.1-2.20.1.2" class="pilcrow">¶</a>
-</dd>
-              <dd class="break"></dd>
-<dt id="section-2.1-2.20.1.3">Different-Forwarding-Treatment OAM:</dt>
-              <dd style="margin-left: 1.5em" id="section-2.1-2.20.1.4">
-                <br>The OAM packets receive different forwarding (e.g., QoS) treatment as user data packets. This was sometimes referred to as "out-of-band".<a href="#section-2.1-2.20.1.4" class="pilcrow">¶</a>
+          <dd style="margin-left: 1.5em" id="section-2.1-2.14">
+            <span class="break"></span><dl class="dlParallel" id="section-2.1-2.14.1">
+              <dt id="section-2.1-2.14.1.1">In-Packet OAM:</dt>
+              <dd style="margin-left: 1.5em" id="section-2.1-2.14.1.2">
+                <br>The OAM information is carried in the packets that also carry the data traffic. This was sometimes referred to as "in-band".<a href="#section-2.1-2.14.1.2" class="pilcrow">¶</a>
 </dd>
             <dd class="break"></dd>
 </dl>
 </dd>
           <dd class="break"></dd>
-<dt id="section-2.1-2.21"></dt>
-          <dd style="margin-left: 1.5em" id="section-2.1-2.22">
+<dt id="section-2.1-2.15"></dt>
+          <dd style="margin-left: 1.5em" id="section-2.1-2.16">
+  The MPLS echo request/reply messages <span>[<a href="#RFC8029" class="cite xref">RFC8029</a>]</span> are an example of "Active OAM", since they are described as "An MPLS echo request/reply is a (possibly MPLS-labeled) IPv4 or IPv6 UDP packet".<a href="#section-2.1-2.16" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-2.1-2.17"></dt>
+          <dd style="margin-left: 1.5em" id="section-2.1-2.18">In situ OAM <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span> is an example of "In-Packet OAM", given that it: '...records OAM information
+  within the packet while the packet traverses a particular network
+  domain.  The term "in situ" refers to the fact that the OAM data is
+  added to the data packets rather than being sent within packets
+  specifically dedicated to OAM.'<a href="#section-2.1-2.18" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-2.1-2.19"></dt>
+          <dd style="margin-left: 1.5em" id="section-2.1-2.20">
+  Initially, "in situ OAM" <span>[<a href="#IETF96-In-Band-OAM" class="cite xref">IETF96-In-Band-OAM</a>]</span> was also referred to as "In-band OAM", but was renamed due to the overloaded meaning of "in-band OAM". Further, <span>[<a href="#RFC9232" class="cite xref">RFC9232</a>]</span> also intertwines the terms "in-band" with "in situ", though <span>[<a href="#I-D.song-opsawg-ifit-framework" class="cite xref">I-D.song-opsawg-ifit-framework</a>]</span> settled on using "in Situ". Other similar uses, including <span>[<a href="#P4-INT-2.1" class="cite xref">P4-INT-2.1</a>]</span> and <span>[<a href="#I-D.kumar-ippm-ifa" class="cite xref">I-D.kumar-ippm-ifa</a>]</span>, still use variations of "in-band", "in band", or "inband".<a href="#section-2.1-2.20" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd><dt id="section-2.1-2.21">Packet Forwarding Treatment OAM:</dt>
+          <dd style="margin-left: 1.5em" id="section-2.1-2.22"> OAM in relation to the forwarding treatment of user data packets, as for example QoS treatment.<a href="#section-2.1-2.22" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-2.1-2.23"></dt>
+          <dd style="margin-left: 1.5em" id="section-2.1-2.24">
+            <span class="break"></span><dl class="dlParallel" id="section-2.1-2.24.1">
+              <dt id="section-2.1-2.24.1.1">Equal-Forwarding-Treatment OAM:</dt>
+              <dd style="margin-left: 1.5em" id="section-2.1-2.24.1.2">
+                <br>The OAM packets receive the same forwarding (e.g., QoS) treatment as user data packets. This was sometimes referred to as "in-band".<a href="#section-2.1-2.24.1.2" class="pilcrow">¶</a>
+</dd>
+              <dd class="break"></dd>
+<dt id="section-2.1-2.24.1.3">Different-Forwarding-Treatment OAM:</dt>
+              <dd style="margin-left: 1.5em" id="section-2.1-2.24.1.4">
+                <br>The OAM packets receive different forwarding (e.g., QoS) treatment as user data packets. This was sometimes referred to as "out-of-band".<a href="#section-2.1-2.24.1.4" class="pilcrow">¶</a>
+</dd>
+            <dd class="break"></dd>
+</dl>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-2.1-2.25"></dt>
+          <dd style="margin-left: 1.5em" id="section-2.1-2.26">
 For a case of either "Non-Path-Congruent OAM" or "Different-Forwarding-Treatment OAM", <span>[<a href="#RFC9551" class="cite xref">RFC9551</a>]</span> says 
 
 "Out-of-band OAM:
 an active OAM method whose path through the DetNet domain may not be topologically identical to the path of the monitored DetNet flow, its test packets may receive different QoS and/or PREOF treatment, or both."
-<span>[<a href="#I-D.ietf-raw-architecture" class="cite xref">I-D.ietf-raw-architecture</a>]</span> uses similar text.<a href="#section-2.1-2.22" class="pilcrow">¶</a>
+<span>[<a href="#I-D.ietf-raw-architecture" class="cite xref">I-D.ietf-raw-architecture</a>]</span> uses similar text.<a href="#section-2.1-2.26" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-2.1-2.23">Combined OAM:</dt>
-          <dd style="margin-left: 1.5em" id="section-2.1-2.24"> OAM in relation to multiple criteria. For example, in relation to both topological congruence and packet treatment. 
-<br><br>
-            <span>[<a href="#RFC9551" class="cite xref">RFC9551</a>]</span> uses Combined OAM when it says 
+<dt id="section-2.1-2.27"></dt>
+          <dd style="margin-left: 1.5em" id="section-2.1-2.28">Note that OAM can be classified in relation to multiple criteria, e.g., relating to both topological congruence and packet treatment, as well as other criteria, such as active, passive or hybrid <span>[<a href="#RFC7799" class="cite xref">RFC7799</a>]</span>. 
+For example, <span>[<a href="#RFC9551" class="cite xref">RFC9551</a>]</span> says 
 
 "In-band OAM: an active OAM method that is in band within
 the monitored DetNet OAM domain when it traverses the
@@ -1529,7 +1542,7 @@ same set of links and interfaces receiving the same QoS and
 Packet Replication, Elimination, and Ordering Functions
 (PREOF) treatment as the monitored DetNet flow."
 
-<span>[<a href="#I-D.ietf-raw-architecture" class="cite xref">I-D.ietf-raw-architecture</a>]</span> uses similar text.<a href="#section-2.1-2.24" class="pilcrow">¶</a>
+<span>[<a href="#I-D.ietf-raw-architecture" class="cite xref">I-D.ietf-raw-architecture</a>]</span> uses similar text.<a href="#section-2.1-2.28" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
@@ -1548,179 +1561,34 @@ Packet Replication, Elimination, and Ordering Functions
 </div>
 </section>
 </div>
-<div id="ippm">
 <section id="section-3">
-      <h2 id="name-active-passive-hybrid-and-c">
-<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-active-passive-hybrid-and-c" class="section-name selfRef">Active, Passive, Hybrid, and Compound OAM</a>
+      <h2 id="name-security-considerations">
+<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
       </h2>
-<p id="section-3-1">
-               <span>[<a href="#RFC7799" class="cite xref">RFC7799</a>]</span> provides clear definitions for active and passive
-               performance assessment such that the construction of metrics and
-               methods can be described as either "Active" or "Passive".  Even
-               though <span>[<a href="#RFC7799" class="cite xref">RFC7799</a>]</span> does not include the specific terms "Active",
-               "Passive", or "Hybrid" as modifiers of "OAM", the following terms
-               are used in many RFCs and are provided here for use in all future
-               IETF documents that refer to OAM.<a href="#section-3-1" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlParallel" id="section-3-2">
-        <dt id="section-3-2.1">Active OAM:</dt>
-        <dd style="margin-left: 1.5em" id="section-3-2.2">
-          <br> Depends on injected, dedicated-packet OAM.<a href="#section-3-2.2" class="pilcrow">¶</a>
-</dd>
-        <dd class="break"></dd>
-<dt id="section-3-2.3">Passive OAM:</dt>
-        <dd style="margin-left: 1.5em" id="section-3-2.4">
-          <br> Depends solely on the observation of one
-      or more existing data packet streams and does not use dedicated-packet OAM.<a href="#section-3-2.4" class="pilcrow">¶</a>
-</dd>
-        <dd class="break"></dd>
-<dt id="section-3-2.5">Hybrid OAM:</dt>
-        <dd style="margin-left: 1.5em" id="section-3-2.6">
-          <br> Uses instrumentation or modification of data packets themselves. <span>[<a href="#RFC9341" class="cite xref">RFC9341</a>]</span> and <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span> are examples labeled "Hybrid OAM" under this definition.<a href="#section-3-2.6" class="pilcrow">¶</a>
-</dd>
-        <dd class="break"></dd>
-<dt id="section-3-2.7">Compound OAM:</dt>
-        <dd style="margin-left: 1.5em" id="section-3-2.8">
-          <p id="section-3-2.8.1"><br> Uses a combination of at least two of Active OAM, Passive OAM, and Hybrid OAM.  Note that
-         Section 3.7 of <span>[<a href="#RFC7799" class="cite xref">RFC7799</a>]</span> also uses the term "Hybrid" to refer to metric types
-         in-between active and passive, for OAM there are no in-betweens per se,
-         only active, passive, hybrid, or a compound combination.
-
-          <br><br>      Compound OAM can be characterized in a more explicit way, for
-      nuanced use-cases, and named according to the OAM types that
-      are combined:<a href="#section-3-2.8.1" class="pilcrow">¶</a></p>
-<ul class="normal">
-<li class="normal" id="section-3-2.8.2.1">
-              <p id="section-3-2.8.2.1.1">Active-Passive OAM.<a href="#section-3-2.8.2.1.1" class="pilcrow">¶</a></p>
-</li>
-            <li class="normal" id="section-3-2.8.2.2">
-              <p id="section-3-2.8.2.2.1">Active-Hybrid OAM.<a href="#section-3-2.8.2.2.1" class="pilcrow">¶</a></p>
-</li>
-            <li class="normal" id="section-3-2.8.2.3">
-              <p id="section-3-2.8.2.3.1">Hybrid-Passive OAM.<a href="#section-3-2.8.2.3.1" class="pilcrow">¶</a></p>
-</li>
-            <li class="normal" id="section-3-2.8.2.4">
-              <p id="section-3-2.8.2.4.1">Active-Hybrid-Passive OAM.<a href="#section-3-2.8.2.4.1" class="pilcrow">¶</a></p>
-</li>
-          </ul>
-<p id="section-3-2.8.3">
-
-          <br>   
-          When two or more OAM types are combined, it is simply the case
-    that both OAM types are used at once. For example, in Active-Passive
-    OAM both specific OAM packets and the observation of data packets 
-    may be used to provide information about the data flow in the network.
-    Each component may supplement the total data.<a href="#section-3-2.8.3" class="pilcrow">¶</a></p>
-</dd>
-      <dd class="break"></dd>
-</dl>
-<p id="section-3-3">
-               Note that <span>[<a href="#RFC7799" class="cite xref">RFC7799</a>]</span> describes "passive methods" as "out of band"
-   which is contrary to the concept of "Passive OAM" as defined here
-   because there are no OAM packets to be in-band or out-of-band.
-
-  Following the guidelines of this document, OAM may be
-   qualified according to the terms described in Sections <a href="#band" class="auto internal xref">2</a> and <a href="#ippm" class="auto internal xref">3</a> of this document, and the term "out of band OAM" is not to be used in future
-   documents.<a href="#section-3-3" class="pilcrow">¶</a></p>
+<p id="section-3-1">Security is improved when terms are used with precision, and their definitions are unambiguous.<a href="#section-3-1" class="pilcrow">¶</a></p>
 </section>
-</div>
-<div id="acronyms">
 <section id="section-4">
-      <h2 id="name-extended-oam-abbreviations">
-<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-extended-oam-abbreviations" class="section-name selfRef">Extended OAM Abbreviations</a>
+      <h2 id="name-iana-considerations">
+<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
       </h2>
-<p id="section-4-1">
-        This document recommends avoiding the creation and use of extended abbreviations for the qualifiers of "OAM". For example, the first "O" in "OOAM" could mean out-of-band, overlay, or something else.<a href="#section-4-1" class="pilcrow">¶</a></p>
-<p id="section-4-2">
-        <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span> and other dependent documents currently uses the abbreviations "IOAM" for In situ Operations, Administration, and Maintenance (IOAM). While this document does not obsolete that abbreviation, it still recommends that the expanded "in situ OAM" is used instead to avoid potential ambiguity.<a href="#section-4-2" class="pilcrow">¶</a></p>
+<p id="section-4-1">This document has no IANA actions.<a href="#section-4-1" class="pilcrow">¶</a></p>
 </section>
-</div>
-<div id="nodetype">
 <section id="section-5">
-      <h2 id="name-processing-of-oam-packets-b">
-<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-processing-of-oam-packets-b" class="section-name selfRef">Processing of OAM Packets by Nodes</a>
+      <h2 id="name-acknowledgements">
+<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
       </h2>
 <p id="section-5-1">
-        There are multiple processing capabilities that nodes processing OAM packets can utilize. Some of those capabilities are explained in <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span> for in situ OAM and are further generalized in this document.<a href="#section-5-1" class="pilcrow">¶</a></p>
+        The creation of this document was triggered when observing one of many on-mailing-list discussions of what these terms mean, and how to abbreviate them. Participants on that mailing thread include, alphabetically: Adrian Farrel, Alexander Vainshtein, Florian Kauer, Frank Brockners, Greg Mirsky, Italo Busi, Loa Andersson, Med Boucadair, Michael Richardson, Quan Xiong, Stewart Bryant, Tom Petch, Eduard Vasilenko, and Xiao Min.<a href="#section-5-1" class="pilcrow">¶</a></p>
 <p id="section-5-2">
-Depending on the Type of OAM processing, nodes are categorized as follows. Please note that this characterization exists within the context of a particular OAM protocol instance, and a given node can support multiple types.<a href="#section-5-2" class="pilcrow">¶</a></p>
-<ul class="normal">
-<li class="normal" id="section-5-3.1">
-          <p id="section-5-3.1.1">
-  Hybrid OAM instruments or modifies data packet themselves. Consequently:<a href="#section-5-3.1.1" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlParallel" id="section-5-3.1.2">
-            <dt id="section-5-3.1.2.1">Encapsulating Node:</dt>
-            <dd style="margin-left: 1.5em" id="section-5-3.1.2.2">
-              <br>Adds OAM information to data packets.<a href="#section-5-3.1.2.2" class="pilcrow">¶</a>
-</dd>
-            <dd class="break"></dd>
-<dt id="section-5-3.1.2.3">Transit Node:</dt>
-            <dd style="margin-left: 1.5em" id="section-5-3.1.2.4">
-              <br>May process OAM information in data packets.<a href="#section-5-3.1.2.4" class="pilcrow">¶</a>
-</dd>
-            <dd class="break"></dd>
-<dt id="section-5-3.1.2.5">Transparent Node:</dt>
-            <dd style="margin-left: 1.5em" id="section-5-3.1.2.6">
-              <br>Does not process or even notice OAM information in data packets. Does not drop OAM packets.<a href="#section-5-3.1.2.6" class="pilcrow">¶</a>
-</dd>
-            <dd class="break"></dd>
-<dt id="section-5-3.1.2.7">Decapsulating Node:</dt>
-            <dd style="margin-left: 1.5em" id="section-5-3.1.2.8">
-              <br>Removes OAM information from data packets.<a href="#section-5-3.1.2.8" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-</dl>
-</li>
-        <li class="normal" id="section-5-3.2">
-          <p id="section-5-3.2.1">
-  Active OAM uses dedicated-packet OAM, separate from data packets. Consequently:<a href="#section-5-3.2.1" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlParallel" id="section-5-3.2.2">
-            <dt id="section-5-3.2.2.1">OAM Source Node:</dt>
-            <dd style="margin-left: 1.5em" id="section-5-3.2.2.2">
-              <br>Creates and injects OAM packets into a flow.<a href="#section-5-3.2.2.2" class="pilcrow">¶</a>
-</dd>
-            <dd class="break"></dd>
-<dt id="section-5-3.2.2.3">OAM Sink Node:</dt>
-            <dd style="margin-left: 1.5em" id="section-5-3.2.2.4">
-              <br>Processes and removes OAM packets from a flow.<a href="#section-5-3.2.2.4" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-</dl>
-<p id="section-5-3.2.3">
-  A node could be an OAM Source Node and an OAM Sink Node for Active OAM packets simultaneously.<a href="#section-5-3.2.3" class="pilcrow">¶</a></p>
-</li>
-      </ul>
-<p id="section-5-4">
-  In some use-cases, such as in situ OAM described in <span>[<a href="#RFC9322" class="cite xref">RFC9322</a>]</span>, Compound OAM is used. In the forward direction, Hybrid OAM is used with a single Encapsulating Node. Multiple Transit Nodes may process the OAM information, and this may trigger them to act as OAM Source Nodes for Active OAM sent back to the Encapsulating Node which serves as an OAM Sink Node.<a href="#section-5-4" class="pilcrow">¶</a></p>
+        The authors wish to thank, chronologically, Hesham Elbakoury, Michael Richardson, Stewart Bryant, Greg Mirsky, Med Boucadair, Loa Andersson, Thomas Graf, Alex Huang Feng, Xiao Min, Dhruv Dhody, Henk Birkholz, Alex Huang Feng, Tom Petch, and Roni Even for their thorough review and useful feedback comments that greatly improved this document.<a href="#section-5-2" class="pilcrow">¶</a></p>
 </section>
-</div>
 <section id="section-6">
-      <h2 id="name-security-considerations">
-<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
-      </h2>
-<p id="section-6-1">Security is improved when terms are used with precision, and their definitions are unambiguous.<a href="#section-6-1" class="pilcrow">¶</a></p>
-</section>
-<section id="section-7">
-      <h2 id="name-iana-considerations">
-<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
-      </h2>
-<p id="section-7-1">This document has no IANA actions.<a href="#section-7-1" class="pilcrow">¶</a></p>
-</section>
-<section id="section-8">
-      <h2 id="name-acknowledgements">
-<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
-      </h2>
-<p id="section-8-1">
-        The creation of this document was triggered when observing one of many on-mailing-list discussions of what these terms mean, and how to abbreviate them. Participants on that mailing thread include, alphabetically: Adrian Farrel, Alexander Vainshtein, Florian Kauer, Frank Brockners, Greg Mirsky, Italo Busi, Loa Andersson, Med Boucadair, Michael Richardson, Quan Xiong, Stewart Bryant, Tom Petch, Eduard Vasilenko, and Xiao Min.<a href="#section-8-1" class="pilcrow">¶</a></p>
-<p id="section-8-2">
-        The authors wish to thank, chronologically, Hesham Elbakoury, Michael Richardson, Stewart Bryant, Greg Mirsky, Med Boucadair, Loa Andersson, Thomas Graf, Alex Huang Feng, Xiao Min, Dhruv Dhody, Henk Birkholz, Alex Huang Feng, Tom Petch, and Roni Even for their thorough review and useful feedback comments that greatly improved this document.<a href="#section-8-2" class="pilcrow">¶</a></p>
-</section>
-<section id="section-9">
       <h2 id="name-references">
-<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-references" class="section-name selfRef">References</a>
+<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-references" class="section-name selfRef">References</a>
       </h2>
-<section id="section-9.1">
+<section id="section-6.1">
         <h3 id="name-normative-references">
-<a href="#section-9.1" class="section-number selfRef">9.1. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
+<a href="#section-6.1" class="section-number selfRef">6.1. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
         </h3>
 <dl class="references">
 <dt id="RFC6291">[RFC6291]</dt>
@@ -1729,14 +1597,14 @@ Depending on the Type of OAM processing, nodes are categorized as follows. Pleas
 <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-9.2">
+<section id="section-6.2">
         <h3 id="name-informative-references">
-<a href="#section-9.2" class="section-number selfRef">9.2. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
+<a href="#section-6.2" class="section-number selfRef">6.2. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
         </h3>
 <dl class="references">
 <dt id="I-D.ietf-raw-architecture">[I-D.ietf-raw-architecture]</dt>
         <dd>
-<span class="refAuthor">Thubert, P.</span>, <span class="refTitle">"Reliable and Available Wireless Architecture"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-ietf-raw-architecture-22</span>, <time datetime="2024-11-14" class="refDate">14 November 2024</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-ietf-raw-architecture-22">https://datatracker.ietf.org/doc/html/draft-ietf-raw-architecture-22</a>&gt;</span>. </dd>
+<span class="refAuthor">Thubert, P.</span>, <span class="refTitle">"Reliable and Available Wireless Architecture"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-ietf-raw-architecture-24</span>, <time datetime="2025-02-28" class="refDate">28 February 2025</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-ietf-raw-architecture-24">https://datatracker.ietf.org/doc/html/draft-ietf-raw-architecture-24</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="I-D.kumar-ippm-ifa">[I-D.kumar-ippm-ifa]</dt>
         <dd>
@@ -1818,6 +1686,19 @@ Depending on the Type of OAM processing, nodes are categorized as follows. Pleas
 <div class="email">
 <span>Email:</span>
 <a href="mailto:adrian@olddog.co.uk" class="email">adrian@olddog.co.uk</a>
+</div>
+</address>
+<address class="vcard">
+        <div dir="auto" class="left"><span class="fn nameRole">Tal Mizrahi</span></div>
+<div dir="auto" class="left"><span class="org">Huawei</span></div>
+<div dir="auto" class="left"><span class="street-address">Matam</span></div>
+<div dir="auto" class="left">
+<span class="locality">Haifa</span> <span class="postal-code">3190501</span>
+</div>
+<div dir="auto" class="left"><span class="country-name">Israel</span></div>
+<div class="email">
+<span>Email:</span>
+<a href="mailto:tal.mizrahi.phd@gmail.com" class="email">tal.mizrahi.phd@gmail.com</a>
 </div>
 </address>
 </section>

--- a/draft-ietf-opsawg-oam-characterization.txt
+++ b/draft-ietf-opsawg-oam-characterization.txt
@@ -6,11 +6,13 @@ OPS Area Working Group                                      C. Pignataro
 Internet-Draft                                      Blue Fern Consulting
 Updates: 6291 (if approved)                                    A. Farrel
 Intended status: Best Current Practice                Old Dog Consulting
-Expires: 1 July 2025                                    28 December 2024
+Expires: 12 October 2025                                      T. Mizrahi
+                                                                  Huawei
+                                                           10 April 2025
 
 
                   Guidelines for Characterizing "OAM"
-               draft-ietf-opsawg-oam-characterization-04
+               draft-ietf-opsawg-oam-characterization-05
 
 Abstract
 
@@ -47,20 +49,18 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 1 July 2025.
+   This Internet-Draft will expire on 12 October 2025.
 
 
 
-
-
-Pignataro & Farrel         Expires 1 July 2025                  [Page 1]
+Pignataro, et al.        Expires 12 October 2025                [Page 1]
 
-Internet-Draft             Characterizing OAM              December 2024
+Internet-Draft             Characterizing OAM                 April 2025
 
 
 Copyright Notice
 
-   Copyright (c) 2024 IETF Trust and the persons identified as the
+   Copyright (c) 2025 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -78,16 +78,13 @@ Table of Contents
    2.  In-Band and Out-of-Band OAM . . . . . . . . . . . . . . . . .   3
      2.1.  Terminology and Guidance  . . . . . . . . . . . . . . . .   3
      2.2.  Historical Uses . . . . . . . . . . . . . . . . . . . . .   5
-   3.  Active, Passive, Hybrid, and Compound OAM . . . . . . . . . .   5
-   4.  Extended OAM Abbreviations  . . . . . . . . . . . . . . . . .   7
-   5.  Processing of OAM Packets by Nodes  . . . . . . . . . . . . .   7
-   6.  Security Considerations . . . . . . . . . . . . . . . . . . .   8
-   7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   8
-   8.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   8
-   9.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   8
-     9.1.  Normative References  . . . . . . . . . . . . . . . . . .   8
-     9.2.  Informative References  . . . . . . . . . . . . . . . . .   8
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  10
+   3.  Security Considerations . . . . . . . . . . . . . . . . . . .   5
+   4.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   5
+   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   6
+   6.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   6
+     6.1.  Normative References  . . . . . . . . . . . . . . . . . .   6
+     6.2.  Informative References  . . . . . . . . . . . . . . . . .   6
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .   8
 
 1.  Introduction
 
@@ -104,29 +101,18 @@ Table of Contents
    the OAM abbreviation, and lays out guidelines for their use in future
    IETF work to achieve consistent and unambiguous characterization.
 
-
-
-
-
-
-Pignataro & Farrel         Expires 1 July 2025                  [Page 2]
-
-Internet-Draft             Characterizing OAM              December 2024
-
-
-   Additionally, this document recommends avoiding the creation and use
-   of extended abbreviation for the qualifiers of "OAM".  For example,
-   the first "O" in "OOAM" could mean out-of-band, overlay, or something
-   else.
-
    This document updates [RFC6291] by adding to the guidelines for the
    use of the term "OAM".  It does not modify any other part of
    [RFC6291].
 
-   Note that [RFC7799] defines terms for active and passive performance
-   assessments through metrics and methods.  That RFC does not
-   substantially discuss OAM, and although the concepts are similar,
-   this document does not modify the definitions in [RFC7799].
+
+
+
+
+Pignataro, et al.        Expires 12 October 2025                [Page 2]
+
+Internet-Draft             Characterizing OAM                 April 2025
+
 
 2.  In-Band and Out-of-Band OAM
 
@@ -137,7 +123,7 @@ Internet-Draft             Characterizing OAM              December 2024
 
    While those terms, useful in their simplicity, continued to be
    broadly used to mean "within something" and "outside something", a
-   challenge is presented for IP communications and packet switch
+   challenge is presented for IP communications and packet-switched
    networks (PSNs) which do not have a "band" per se, and, in fact, have
    multiple "somethings" that OAM can be carried within or outside.  A
    frequently encountered case is the use of "in-band" to mean either
@@ -145,30 +131,20 @@ Internet-Draft             Characterizing OAM              December 2024
 
    Within the IETF, the terms "in-band" and "out-of-band" cannot be
    reliably understood consistently and unambiguously.  Context-specific
-   redefinitions of these terms cannot be generalized and can be
-   confused by participants from other contexts.  More importantly, the
-   terms are not self-defining to any further extent and cannot be
-   understood by someone exposed to them for the first time, since there
-   is no "band" in IP.
+   definitions of these terms are inconsistent and therefore cannot be
+   generalized.  More importantly, the terms are not self-defining to
+   any further extent and cannot be understood by someone exposed to
+   them for the first time, since there is no "band" in IP.
 
 2.1.  Terminology and Guidance
 
    The guidance in this document is to avoid the terms "in-band" and
    "out-of-band" when refering to OAM, and instead find finer-
-   granularity descriptive terms.  The definitions presented in this
-   document are for use in all future IETF documents that refer to OAM,
-   and the terms "in-band OAM" and "out-of-band OAM" are not to be used
-   in future documents.
+   granularity descriptive terms.  Alternative terms and definitions are
+   presented in this document for future use in IETF documents that
+   refer to OAM.
 
-   Path OAM:  OAM in relation to a path.
-
-
-
-
-Pignataro & Farrel         Expires 1 July 2025                  [Page 3]
-
-Internet-Draft             Characterizing OAM              December 2024
-
+   Path OAM:  OAM in relation to a path
 
       Path-Congruent OAM:
          The OAM information follows the exact same path as the observed
@@ -184,21 +160,45 @@ Internet-Draft             Characterizing OAM              December 2024
       Congruent OAM", and further describes that the OAM Packets "share
       their fate with data packets."
 
-   Packet OAM:  OAM in relation to a user data packet.
+   Active, Passive, Hybrid, and In-Packet OAM
+
+
+
+
+Pignataro, et al.        Expires 12 October 2025                [Page 3]
+
+Internet-Draft             Characterizing OAM                 April 2025
+
+
+      [RFC7799] provides clear definitions for active and passive
+      performance assessment such that the construction of metrics and
+      methods can be described as either "Active" or "Passive".  Even
+      though [RFC7799] does not include the specific terms "Active",
+      "Passive", or "Hybrid" as modifiers of "OAM", the following terms
+      are used in many RFCs and are provided here for clarity.
+
+      Active OAM:
+         Depends on dedicated OAM packets.
+
+      Passive OAM:
+         Depends solely on the observation of one or more existing data
+         packet streams and does not use dedicated OAM packets.
+
+      Hybrid OAM:
+         Uses instrumentation or modification of data packets
+         themselves.  [RFC9341] and [RFC9197] are examples labeled
+         "Hybrid OAM" under this definition.
+
+      This document defines the term In-Packet OAM, which is a special
+      case of Hybrid OAM:
 
       In-Packet OAM:
          The OAM information is carried in the packets that also carry
          the data traffic.  This was sometimes referred to as "in-band".
 
-      Dedicated-Packet OAM:
-         The OAM information is carried in its own OAM packets, separate
-         from data traffic.  This was sometimes referred to as "out-of-
-         band".
-
       The MPLS echo request/reply messages [RFC8029] are an example of
-      "Dedicated-Packet OAM", since they are described as "An MPLS echo
-      request/reply is a (possibly MPLS-labeled) IPv4 or IPv6 UDP
-      packet".
+      "Active OAM", since they are described as "An MPLS echo request/
+      reply is a (possibly MPLS-labeled) IPv4 or IPv6 UDP packet".
 
       In situ OAM [RFC9197] is an example of "In-Packet OAM", given that
       it: '...records OAM information within the packet while the packet
@@ -221,9 +221,9 @@ Internet-Draft             Characterizing OAM              December 2024
 
 
 
-Pignataro & Farrel         Expires 1 July 2025                  [Page 4]
+Pignataro, et al.        Expires 12 October 2025                [Page 4]
 
-Internet-Draft             Characterizing OAM              December 2024
+Internet-Draft             Characterizing OAM                 April 2025
 
 
          The OAM packets receive the same forwarding (e.g., QoS)
@@ -242,15 +242,15 @@ Internet-Draft             Characterizing OAM              December 2024
       its test packets may receive different QoS and/or PREOF treatment,
       or both."  [I-D.ietf-raw-architecture] uses similar text.
 
-   Combined OAM:  OAM in relation to multiple criteria.  For example, in
-      relation to both topological congruence and packet treatment.
-
-      [RFC9551] uses Combined OAM when it says "In-band OAM: an active
-      OAM method that is in band within the monitored DetNet OAM domain
-      when it traverses the same set of links and interfaces receiving
-      the same QoS and Packet Replication, Elimination, and Ordering
-      Functions (PREOF) treatment as the monitored DetNet flow."
-      [I-D.ietf-raw-architecture] uses similar text.
+      Note that OAM can be classified in relation to multiple criteria,
+      e.g., relating to both topological congruence and packet
+      treatment, as well as other criteria, such as active, passive or
+      hybrid [RFC7799].  For example, [RFC9551] says "In-band OAM: an
+      active OAM method that is in band within the monitored DetNet OAM
+      domain when it traverses the same set of links and interfaces
+      receiving the same QoS and Packet Replication, Elimination, and
+      Ordering Functions (PREOF) treatment as the monitored DetNet
+      flow."  [I-D.ietf-raw-architecture] uses similar text.
 
 2.2.  Historical Uses
 
@@ -265,155 +265,24 @@ Internet-Draft             Characterizing OAM              December 2024
    faith as PW data)".  Hence, in that specific case, the term "band"
    refers to the "Pseudowire data".
 
-3.  Active, Passive, Hybrid, and Compound OAM
-
-   [RFC7799] provides clear definitions for active and passive
-   performance assessment such that the construction of metrics and
-   methods can be described as either "Active" or "Passive".  Even
-   though [RFC7799] does not include the specific terms "Active",
-   "Passive", or "Hybrid" as modifiers of "OAM", the following terms are
-   used in many RFCs and are provided here for use in all future IETF
-   documents that refer to OAM.
-
-
-
-Pignataro & Farrel         Expires 1 July 2025                  [Page 5]
-
-Internet-Draft             Characterizing OAM              December 2024
-
-
-   Active OAM:
-      Depends on injected, dedicated-packet OAM.
-
-   Passive OAM:
-      Depends solely on the observation of one or more existing data
-      packet streams and does not use dedicated-packet OAM.
-
-   Hybrid OAM:
-      Uses instrumentation or modification of data packets themselves.
-      [RFC9341] and [RFC9197] are examples labeled "Hybrid OAM" under
-      this definition.
-
-   Compound OAM:
-      Uses a combination of at least two of Active OAM, Passive OAM, and
-      Hybrid OAM.  Note that Section 3.7 of [RFC7799] also uses the term
-      "Hybrid" to refer to metric types in-between active and passive,
-      for OAM there are no in-betweens per se, only active, passive,
-      hybrid, or a compound combination.
-
-      Compound OAM can be characterized in a more explicit way, for
-      nuanced use-cases, and named according to the OAM types that are
-      combined:
-
-      *  Active-Passive OAM.
-
-      *  Active-Hybrid OAM.
-
-      *  Hybrid-Passive OAM.
-
-      *  Active-Hybrid-Passive OAM.
-
-
-      When two or more OAM types are combined, it is simply the case
-      that both OAM types are used at once.  For example, in Active-
-      Passive OAM both specific OAM packets and the observation of data
-      packets may be used to provide information about the data flow in
-      the network.  Each component may supplement the total data.
-
-   Note that [RFC7799] describes "passive methods" as "out of band"
-   which is contrary to the concept of "Passive OAM" as defined here
-   because there are no OAM packets to be in-band or out-of-band.
-   Following the guidelines of this document, OAM may be qualified
-   according to the terms described in Sections 2 and 3 of this
-   document, and the term "out of band OAM" is not to be used in future
-   documents.
-
-
-
-
-
-
-Pignataro & Farrel         Expires 1 July 2025                  [Page 6]
-
-Internet-Draft             Characterizing OAM              December 2024
-
-
-4.  Extended OAM Abbreviations
-
-   This document recommends avoiding the creation and use of extended
-   abbreviations for the qualifiers of "OAM".  For example, the first
-   "O" in "OOAM" could mean out-of-band, overlay, or something else.
-
-   [RFC9197] and other dependent documents currently uses the
-   abbreviations "IOAM" for In situ Operations, Administration, and
-   Maintenance (IOAM).  While this document does not obsolete that
-   abbreviation, it still recommends that the expanded "in situ OAM" is
-   used instead to avoid potential ambiguity.
-
-5.  Processing of OAM Packets by Nodes
-
-   There are multiple processing capabilities that nodes processing OAM
-   packets can utilize.  Some of those capabilities are explained in
-   [RFC9197] for in situ OAM and are further generalized in this
-   document.
-
-   Depending on the Type of OAM processing, nodes are categorized as
-   follows.  Please note that this characterization exists within the
-   context of a particular OAM protocol instance, and a given node can
-   support multiple types.
-
-   *  Hybrid OAM instruments or modifies data packet themselves.
-      Consequently:
-
-      Encapsulating Node:
-         Adds OAM information to data packets.
-
-      Transit Node:
-         May process OAM information in data packets.
-
-      Transparent Node:
-         Does not process or even notice OAM information in data
-         packets.  Does not drop OAM packets.
-
-      Decapsulating Node:
-         Removes OAM information from data packets.
-
-   *  Active OAM uses dedicated-packet OAM, separate from data packets.
-      Consequently:
-
-      OAM Source Node:
-         Creates and injects OAM packets into a flow.
-
-      OAM Sink Node:
-         Processes and removes OAM packets from a flow.
-
-
-
-Pignataro & Farrel         Expires 1 July 2025                  [Page 7]
-
-Internet-Draft             Characterizing OAM              December 2024
-
-
-      A node could be an OAM Source Node and an OAM Sink Node for Active
-      OAM packets simultaneously.
-
-   In some use-cases, such as in situ OAM described in [RFC9322],
-   Compound OAM is used.  In the forward direction, Hybrid OAM is used
-   with a single Encapsulating Node.  Multiple Transit Nodes may process
-   the OAM information, and this may trigger them to act as OAM Source
-   Nodes for Active OAM sent back to the Encapsulating Node which serves
-   as an OAM Sink Node.
-
-6.  Security Considerations
+3.  Security Considerations
 
    Security is improved when terms are used with precision, and their
    definitions are unambiguous.
 
-7.  IANA Considerations
+4.  IANA Considerations
 
    This document has no IANA actions.
 
-8.  Acknowledgements
+
+
+
+Pignataro, et al.        Expires 12 October 2025                [Page 5]
+
+Internet-Draft             Characterizing OAM                 April 2025
+
+
+5.  Acknowledgements
 
    The creation of this document was triggered when observing one of
    many on-mailing-list discussions of what these terms mean, and how to
@@ -430,9 +299,9 @@ Internet-Draft             Characterizing OAM              December 2024
    thorough review and useful feedback comments that greatly improved
    this document.
 
-9.  References
+6.  References
 
-9.1.  Normative References
+6.1.  Normative References
 
    [RFC6291]  Andersson, L., van Helvoort, H., Bonica, R., Romascanu,
               D., and S. Mansfield, "Guidelines for the Use of the "OAM"
@@ -440,22 +309,14 @@ Internet-Draft             Characterizing OAM              December 2024
               DOI 10.17487/RFC6291, June 2011,
               <https://www.rfc-editor.org/info/rfc6291>.
 
-9.2.  Informative References
-
-
-
-
-Pignataro & Farrel         Expires 1 July 2025                  [Page 8]
-
-Internet-Draft             Characterizing OAM              December 2024
-
+6.2.  Informative References
 
    [I-D.ietf-raw-architecture]
               Thubert, P., "Reliable and Available Wireless
               Architecture", Work in Progress, Internet-Draft, draft-
-              ietf-raw-architecture-22, 14 November 2024,
+              ietf-raw-architecture-24, 28 February 2025,
               <https://datatracker.ietf.org/doc/html/draft-ietf-raw-
-              architecture-22>.
+              architecture-24>.
 
    [I-D.kumar-ippm-ifa]
               Kumar, J., Anubolu, S., Lemon, J., Manur, R., Holbrook,
@@ -469,6 +330,14 @@ Internet-Draft             Characterizing OAM              December 2024
               Song, H., Qin, F., Chen, H., Jin, J., and J. Shin,
               "Framework for In-situ Flow Information Telemetry", Work
               in Progress, Internet-Draft, draft-song-opsawg-ifit-
+
+
+
+Pignataro, et al.        Expires 12 October 2025                [Page 6]
+
+Internet-Draft             Characterizing OAM                 April 2025
+
+
               framework-21, 23 October 2023,
               <https://datatracker.ietf.org/doc/html/draft-song-opsawg-
               ifit-framework-21>.
@@ -496,16 +365,6 @@ Internet-Draft             Characterizing OAM              December 2024
               Channel for Pseudowires", RFC 5085, DOI 10.17487/RFC5085,
               December 2007, <https://www.rfc-editor.org/info/rfc5085>.
 
-
-
-
-
-
-Pignataro & Farrel         Expires 1 July 2025                  [Page 9]
-
-Internet-Draft             Characterizing OAM              December 2024
-
-
    [RFC6669]  Sprecher, N. and L. Fang, "An Overview of the Operations,
               Administration, and Maintenance (OAM) Toolset for MPLS-
               Based Transport Networks", RFC 6669, DOI 10.17487/RFC6669,
@@ -525,6 +384,15 @@ Internet-Draft             Characterizing OAM              December 2024
               Ed., "Data Fields for In Situ Operations, Administration,
               and Maintenance (IOAM)", RFC 9197, DOI 10.17487/RFC9197,
               May 2022, <https://www.rfc-editor.org/info/rfc9197>.
+
+
+
+
+
+Pignataro, et al.        Expires 12 October 2025                [Page 7]
+
+Internet-Draft             Characterizing OAM                 April 2025
+
 
    [RFC9232]  Song, H., Qin, F., Martinez-Julia, P., Ciavaglia, L., and
               A. Wang, "Network Telemetry Framework", RFC 9232,
@@ -556,18 +424,18 @@ Authors' Addresses
    Email: cpignata@gmail.com, carlos@bluefern.consulting
 
 
-
-Pignataro & Farrel         Expires 1 July 2025                 [Page 10]
-
-Internet-Draft             Characterizing OAM              December 2024
-
-
    Adrian Farrel
    Old Dog Consulting
    United Kingdom
    Email: adrian@olddog.co.uk
 
 
+   Tal Mizrahi
+   Huawei
+   Matam
+   Haifa 3190501
+   Israel
+   Email: tal.mizrahi.phd@gmail.com
 
 
 
@@ -577,40 +445,4 @@ Internet-Draft             Characterizing OAM              December 2024
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Pignataro & Farrel         Expires 1 July 2025                 [Page 11]
+Pignataro, et al.        Expires 12 October 2025                [Page 8]

--- a/draft-ietf-opsawg-oam-characterization.xml
+++ b/draft-ietf-opsawg-oam-characterization.xml
@@ -102,9 +102,6 @@
    characterization.
       </t>
       <t>
-        Additionally, this document recommends avoiding the creation and use of extended abbreviation for the qualifiers of "OAM". For example, the first "O" in "OOAM" could mean out-of-band, overlay, or something else.
-      </t>
-      <t>
    This document updates <xref target="RFC6291" /> by adding to the guidelines for the
    use of the term "OAM". It does not modify any other part of <xref target="RFC6291" />.
       </t>
@@ -129,15 +126,13 @@
 
         <t>
           The guidance in this document is to avoid the terms "in-band" and "out-of-band" when refering to OAM, and instead find finer-granularity descriptive terms.
-          The definitions presented in this document are for use in all future IETF documents that refer
-   to OAM, and the terms "in-band OAM" and "out-of-band OAM" are not to
-   be used in future documents.
+          Alternative terms and definitions are presented in this document for future use in IETF documents that refer to OAM.
 
 
           <list style="hanging">
 
 
-<t hangText="Path OAM:"> OAM in relation to a path.</t>
+<t hangText="Path OAM:"> OAM in relation to a path</t>
 <t>
           <list style="hanging">
 <t hangText="Path-Congruent OAM:"><br />The OAM information follows the exact same path as the observed data traffic. This was sometimes referred to as "in-band".</t>
@@ -158,8 +153,7 @@
                methods can be described as either "Active" or "Passive".  Even
                though <xref target="RFC7799" /> does not include the specific terms "Active",
                "Passive", or "Hybrid" as modifiers of "OAM", the following terms
-               are used in many RFCs and are provided here for use in all future
-               IETF documents that refer to OAM.
+               are used in many RFCs and are provided here for clarity.
           
             <list style="hanging">
               <t hangText="Active OAM:"><br /> Depends on dedicated OAM packets.</t>

--- a/draft-ietf-opsawg-oam-characterization.xml
+++ b/draft-ietf-opsawg-oam-characterization.xml
@@ -108,12 +108,6 @@
    This document updates <xref target="RFC6291" /> by adding to the guidelines for the
    use of the term "OAM". It does not modify any other part of <xref target="RFC6291" />.
       </t>
-      <t>
-        Note that <xref target="RFC7799" /> defines terms for active and passive
-performance assessments through metrics and methods. That RFC does not
-substantially discuss OAM, and although the concepts are similar, this
-document does not modify the definitions in <xref target="RFC7799" />.
-      </t>
 
     </section>
 
@@ -124,7 +118,7 @@ document does not modify the definitions in <xref target="RFC7799" />.
           Historically, the terms "in-band" and "out-of-band" were used extensively in radio communications as well as in telephony signaling <xref target="RFC4733" />. In both these cases, there is an actual "Band" (i.e., a "Channel" or "Frequency") to be within or outside.
         </t>
         <t>
-          While those terms, useful in their simplicity, continued to be broadly used to mean "within something" and "outside something", a challenge is presented for IP communications and packet switch networks (PSNs) which do not have a "band" per se, and, in fact, have multiple "somethings" that OAM can be carried within or outside. A frequently encountered case is the use of "in-band" to mean either in-packet or on-path.
+          While those terms, useful in their simplicity, continued to be broadly used to mean "within something" and "outside something", a challenge is presented for IP communications and packet-switched networks (PSNs) which do not have a "band" per se, and, in fact, have multiple "somethings" that OAM can be carried within or outside. A frequently encountered case is the use of "in-band" to mean either in-packet or on-path.
         </t>
         <t>
           Within the IETF, the terms "in-band" and "out-of-band" cannot be reliably understood consistently and unambiguously. Context-specific redefinitions of these terms cannot be generalized and can be confused by participants from other contexts. More importantly, the terms are not self-defining to any further extent and cannot be understood by someone exposed to them for the first time, since there is no "band" in IP.
@@ -156,16 +150,35 @@ document does not modify the definitions in <xref target="RFC7799" />.
 
 
 
-<t hangText="Packet OAM:"> OAM in relation to a user data packet.</t>
+<t hangText="Active, Passive, Hybrid, and In-Packet OAM"></t>
+
+          <t>
+               <xref target="RFC7799" /> provides clear definitions for active and passive
+               performance assessment such that the construction of metrics and
+               methods can be described as either "Active" or "Passive".  Even
+               though <xref target="RFC7799" /> does not include the specific terms "Active",
+               "Passive", or "Hybrid" as modifiers of "OAM", the following terms
+               are used in many RFCs and are provided here for use in all future
+               IETF documents that refer to OAM.
+          
+            <list style="hanging">
+              <t hangText="Active OAM:"><br /> Depends on dedicated OAM packets.</t>
+              <t hangText="Passive OAM:"><br /> Depends solely on the observation of one
+      or more existing data packet streams and does not use dedicated OAM packets.</t>
+               <t hangText="Hybrid OAM:"><br /> Uses instrumentation or modification of data packets themselves. <xref target="RFC9341" /> and <xref target="RFC9197" /> are examples labeled "Hybrid OAM" under this definition.
+               </t>
+            </list>
+          </t>
+
+            <t>This document defines the term In-Packet OAM, which is a special case of Hybrid OAM:</t>
 <t>
           <list style="hanging">
 <t hangText="In-Packet OAM:"><br />The OAM information is carried in the packets that also carry the data traffic. This was sometimes referred to as "in-band".</t>
-<t hangText="Dedicated-Packet OAM:"><br />The OAM information is carried in its own OAM packets, separate from data traffic. This was sometimes referred to as "out-of-band".</t>
           </list>
 </t>
 
 <t>
-  The MPLS echo request/reply messages <xref target="RFC8029" /> are an example of "Dedicated-Packet OAM", since they are described as "An MPLS echo request/reply is a (possibly MPLS-labeled) IPv4 or IPv6 UDP packet".
+  The MPLS echo request/reply messages <xref target="RFC8029" /> are an example of "Active OAM", since they are described as "An MPLS echo request/reply is a (possibly MPLS-labeled) IPv4 or IPv6 UDP packet".
 </t>
 
 
@@ -206,15 +219,8 @@ an active OAM method whose path through the DetNet domain may not be topological
 
 
 
-<t hangText="Combined OAM:"> OAM in relation to multiple criteria. For example, in relation to both topological congruence and packet treatment. 
-<!--
-Examples include
-<xref target="RFC9551" />
-and
-<xref target="I-D.ietf-raw-architecture" />.
--->
-<br /><br />
-<xref target="RFC9551" /> uses Combined OAM when it says 
+<t>Note that OAM can be classified in relation to multiple criteria, e.g., relating to both topological congruence and packet treatment, as well as other criteria, such as active, passive or hybrid <xref target="RFC7799" />. 
+For example, <xref target="RFC9551" /> says 
 
 "In-band OAM: an active OAM method that is in band within
 the monitored DetNet OAM domain when it traverses the
@@ -246,119 +252,6 @@ Packet Replication, Elimination, and Ordering Functions
 
 
       </section>
-
-
-
-    <section anchor="ippm" title="Active, Passive, Hybrid, and Compound OAM">
-          <t>
-               <xref target="RFC7799" /> provides clear definitions for active and passive
-               performance assessment such that the construction of metrics and
-               methods can be described as either "Active" or "Passive".  Even
-               though <xref target="RFC7799" /> does not include the specific terms "Active",
-               "Passive", or "Hybrid" as modifiers of "OAM", the following terms
-               are used in many RFCs and are provided here for use in all future
-               IETF documents that refer to OAM.
-          
-            <list style="hanging">
-              <t hangText="Active OAM:"><br /> Depends on injected, dedicated-packet OAM.</t>
-              <t hangText="Passive OAM:"><br /> Depends solely on the observation of one
-      or more existing data packet streams and does not use dedicated-packet OAM.</t>
-
-
-
-               <t hangText="Hybrid OAM:"><br /> Uses instrumentation or modification of data packets themselves. <xref target="RFC9341" /> and <xref target="RFC9197" /> are examples labeled "Hybrid OAM" under this definition.
-               </t>
-               <t hangText="Compound OAM:"><br /> Uses a combination of at least two of Active OAM, Passive OAM, and Hybrid OAM.  Note that
-         Section 3.7 of <xref target="RFC7799" /> also uses the term "Hybrid" to refer to metric types
-         in-between active and passive, for OAM there are no in-betweens per se,
-         only active, passive, hybrid, or a compound combination.
-
-          <br /><br />      Compound OAM can be characterized in a more explicit way, for
-      nuanced use-cases, and named according to the OAM types that
-      are combined:
-
-
-              <list style="symbols">
-              <t>Active-Passive OAM.</t>
-              <t>Active-Hybrid OAM.</t>
-              <t>Hybrid-Passive OAM.</t>
-              <t>Active-Hybrid-Passive OAM.</t>
-              </list>
-
-          <br />   
-          When two or more OAM types are combined, it is simply the case
-    that both OAM types are used at once. For example, in Active-Passive
-    OAM both specific OAM packets and the observation of data packets 
-    may be used to provide information about the data flow in the network.
-    Each component may supplement the total data. 
-
-            </t>
-            </list>
-
-
-          </t>
-          <t>
-               Note that <xref target="RFC7799" /> describes "passive methods" as "out of band"
-   which is contrary to the concept of "Passive OAM" as defined here
-   because there are no OAM packets to be in-band or out-of-band.
-
-  Following the guidelines of this document, OAM may be
-   qualified according to the terms described in Sections <xref target="band" format="counter" /> and <xref target="ippm" format="counter" /> of this document, and the term "out of band OAM" is not to be used in future
-   documents.
-</t>
-
-    </section>
-
-
-    <section anchor="acronyms" title="Extended OAM Abbreviations">
-            <t>
-        This document recommends avoiding the creation and use of extended abbreviations for the qualifiers of "OAM". For example, the first "O" in "OOAM" could mean out-of-band, overlay, or something else.
-      </t>
-      <t>
-        <xref target="RFC9197" /> and other dependent documents currently uses the abbreviations "IOAM" for In situ Operations, Administration, and Maintenance (IOAM). While this document does not obsolete that abbreviation, it still recommends that the expanded "in situ OAM" is used instead to avoid potential ambiguity.
-      </t>
-
-
-
-    </section>
-
-
-
-    <section anchor="nodetype" title="Processing of OAM Packets by Nodes">
-            <t>
-        There are multiple processing capabilities that nodes processing OAM packets can utilize. Some of those capabilities are explained in <xref target="RFC9197" /> for in situ OAM and are further generalized in this document.
-      </t>
-      <t>
-Depending on the Type of OAM processing, nodes are categorized as follows. Please note that this characterization exists within the context of a particular OAM protocol instance, and a given node can support multiple types.
-
-<list style="bullets">
-
-<t>
-  Hybrid OAM instruments or modifies data packet themselves. Consequently:
-  <list style="hanging">
-    <t hangText="Encapsulating Node:"><br />Adds OAM information to data packets.</t>
-    <t hangText="Transit Node:"><br />May process OAM information in data packets.</t>
-    <t hangText="Transparent Node:"><br />Does not process or even notice OAM information in data packets. Does not drop OAM packets.</t>
-    <t hangText="Decapsulating Node:"><br />Removes OAM information from data packets.</t>
-  </list>
-</t>
-<t>
-  Active OAM uses dedicated-packet OAM, separate from data packets. Consequently:
-  <list style="hanging">
-    <t hangText="OAM Source Node:"><br />Creates and injects OAM packets into a flow.</t>
-    <t hangText="OAM Sink Node:"><br />Processes and removes OAM packets from a flow.</t>
-  </list>
-  A node could be an OAM Source Node and an OAM Sink Node for Active OAM packets simultaneously.
-</t>
-</list></t>
-
-<t>
-  In some use-cases, such as in situ OAM described in <xref target="RFC9322" />, Compound OAM is used. In the forward direction, Hybrid OAM is used with a single Encapsulating Node. Multiple Transit Nodes may process the OAM information, and this may trigger them to act as OAM Source Nodes for Active OAM sent back to the Encapsulating Node which serves as an OAM Sink Node.
-</t>
-
-
-
-    </section>
 
 
 

--- a/draft-ietf-opsawg-oam-characterization.xml
+++ b/draft-ietf-opsawg-oam-characterization.xml
@@ -24,7 +24,7 @@
 <?rfc rfcedstyle="yes"?>
 <?rfc subcompact="no" ?>
 <?rfc symrefs="yes"?>
-<rfc category="bcp" docName="draft-ietf-opsawg-oam-characterization-04" 
+<rfc category="bcp" docName="draft-ietf-opsawg-oam-characterization-05" 
   ipr="trust200902" submissionType="IETF" consensus="true" updates="6291">
   <?xml-stylesheet type='text/xsl' href='rfc2629.xslt' ?>
   <?rfc toc="yes" ?>
@@ -60,6 +60,24 @@
       </address>
     </author>
 
+    <author fullname="Tal Mizrahi" initials="T." surname="Mizrahi">
+      <organization abbrev="">Huawei</organization>
+
+      <address>
+        <postal>
+          <street>Matam</street>
+
+          <city>Haifa</city>
+
+          <code>3190501</code>
+
+          <country>Israel</country>
+        </postal>
+
+        <email>tal.mizrahi.phd@gmail.com</email>
+      </address>
+    </author>
+    
     
     <date />
 
@@ -118,7 +136,7 @@
           While those terms, useful in their simplicity, continued to be broadly used to mean "within something" and "outside something", a challenge is presented for IP communications and packet-switched networks (PSNs) which do not have a "band" per se, and, in fact, have multiple "somethings" that OAM can be carried within or outside. A frequently encountered case is the use of "in-band" to mean either in-packet or on-path.
         </t>
         <t>
-          Within the IETF, the terms "in-band" and "out-of-band" cannot be reliably understood consistently and unambiguously. Context-specific redefinitions of these terms cannot be generalized and can be confused by participants from other contexts. More importantly, the terms are not self-defining to any further extent and cannot be understood by someone exposed to them for the first time, since there is no "band" in IP.
+          Within the IETF, the terms "in-band" and "out-of-band" cannot be reliably understood consistently and unambiguously. Context-specific definitions of these terms are inconsistent and therefore cannot be generalized. More importantly, the terms are not self-defining to any further extent and cannot be understood by someone exposed to them for the first time, since there is no "band" in IP.
         </t>
 
       <section anchor="terms" title="Terminology and Guidance">


### PR DESCRIPTION
The main changes compared to the previous version:
- The document has been trimmed to focus on the in/out-of-band and alternative terms.
- Removed: extended abbreviation text, processing of OAM packets, "compound OAM".
- Integrated the active/passive/hybrid terminology into Section 2, making in-packet OAM a special case of hybrid OAM, and removed dedicated-packet OAM.
- Removed the term "combined OAM" while leaving the clarifying text.
- Some additional clarifications based on comments from the reviewers.
