### PR TITLE
Hybrid OAM clarification

### DIFF
--- a/draft-ietf-opsawg-oam-characterization.html
+++ b/draft-ietf-opsawg-oam-characterization.html
@@ -1232,7 +1232,7 @@ li > p:last-of-type:only-child {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Pignataro, et al.</td>
-<td class="center">Expires 12 October 2025</td>
+<td class="center">Expires 24 October 2025</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1248,12 +1248,12 @@ li > p:last-of-type:only-child {
 <a href="https://www.rfc-editor.org/rfc/rfc6291" class="eref">6291</a> (if approved)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2025-04-10" class="published">10 April 2025</time>
+<time datetime="2025-04-22" class="published">22 April 2025</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Best Current Practice</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2025-10-12">12 October 2025</time></dd>
+<dd class="expires"><time datetime="2025-10-24">24 October 2025</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1309,7 +1309,7 @@ li > p:last-of-type:only-child {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 12 October 2025.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 24 October 2025.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1465,7 +1465,13 @@ li > p:last-of-type:only-child {
               <dd class="break"></dd>
 <dt id="section-2.1-2.10.2.5">Hybrid OAM:</dt>
               <dd style="margin-left: 1.5em" id="section-2.1-2.10.2.6">
-                <br> Uses instrumentation or modification of data packets themselves. <span>[<a href="#RFC9341" class="cite xref">RFC9341</a>]</span> and <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span> are examples labeled "Hybrid OAM" under this definition.<a href="#section-2.1-2.10.2.6" class="pilcrow">¶</a>
+                <br> Uses instrumentation or modification of data 
+                 packets themselves. Examples of protocols classified under "Hybrid OAM" 
+                 include <span>[<a href="#RFC9341" class="cite xref">RFC9341</a>]</span> and <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span>. Hybrid 
+                 OAM can be implemented by piggybacking OAM-related information onto data 
+                 packets, as seen in <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span>, or by utilizing reserved 
+                 fields in the packet header or specific values of existing header fields, 
+                 as proposed in <span>[<a href="#RFC9341" class="cite xref">RFC9341</a>]</span>.<a href="#section-2.1-2.10.2.6" class="pilcrow">¶</a>
 </dd>
             <dd class="break"></dd>
 </dl>

--- a/draft-ietf-opsawg-oam-characterization.txt
+++ b/draft-ietf-opsawg-oam-characterization.txt
@@ -6,9 +6,9 @@ OPS Area Working Group                                      C. Pignataro
 Internet-Draft                                      Blue Fern Consulting
 Updates: 6291 (if approved)                                    A. Farrel
 Intended status: Best Current Practice                Old Dog Consulting
-Expires: 12 October 2025                                      T. Mizrahi
+Expires: 24 October 2025                                      T. Mizrahi
                                                                   Huawei
-                                                           10 April 2025
+                                                           22 April 2025
 
 
                   Guidelines for Characterizing "OAM"
@@ -49,11 +49,11 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 12 October 2025.
+   This Internet-Draft will expire on 24 October 2025.
 
 
 
-Pignataro, et al.        Expires 12 October 2025                [Page 1]
+Pignataro, et al.        Expires 24 October 2025                [Page 1]
 
 Internet-Draft             Characterizing OAM                 April 2025
 
@@ -79,7 +79,7 @@ Table of Contents
      2.1.  Terminology and Guidance  . . . . . . . . . . . . . . . .   3
      2.2.  Historical Uses . . . . . . . . . . . . . . . . . . . . .   5
    3.  Security Considerations . . . . . . . . . . . . . . . . . . .   5
-   4.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   5
+   4.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   6
    5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   6
    6.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   6
      6.1.  Normative References  . . . . . . . . . . . . . . . . . .   6
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Pignataro, et al.        Expires 12 October 2025                [Page 2]
+Pignataro, et al.        Expires 24 October 2025                [Page 2]
 
 Internet-Draft             Characterizing OAM                 April 2025
 
@@ -165,7 +165,7 @@ Internet-Draft             Characterizing OAM                 April 2025
 
 
 
-Pignataro, et al.        Expires 12 October 2025                [Page 3]
+Pignataro, et al.        Expires 24 October 2025                [Page 3]
 
 Internet-Draft             Characterizing OAM                 April 2025
 
@@ -186,8 +186,12 @@ Internet-Draft             Characterizing OAM                 April 2025
 
       Hybrid OAM:
          Uses instrumentation or modification of data packets
-         themselves.  [RFC9341] and [RFC9197] are examples labeled
-         "Hybrid OAM" under this definition.
+         themselves.  Examples of protocols classified under "Hybrid
+         OAM" include [RFC9341] and [RFC9197].  Hybrid OAM can be
+         implemented by piggybacking OAM-related information onto data
+         packets, as seen in [RFC9197], or by utilizing reserved fields
+         in the packet header or specific values of existing header
+         fields, as proposed in [RFC9341].
 
       This document defines the term In-Packet OAM, which is a special
       case of Hybrid OAM:
@@ -214,18 +218,18 @@ Internet-Draft             Characterizing OAM                 April 2025
       [P4-INT-2.1] and [I-D.kumar-ippm-ifa], still use variations of
       "in-band", "in band", or "inband".
 
-   Packet Forwarding Treatment OAM:  OAM in relation to the forwarding
-      treatment of user data packets, as for example QoS treatment.
-
-      Equal-Forwarding-Treatment OAM:
 
 
 
-Pignataro, et al.        Expires 12 October 2025                [Page 4]
+Pignataro, et al.        Expires 24 October 2025                [Page 4]
 
 Internet-Draft             Characterizing OAM                 April 2025
 
 
+   Packet Forwarding Treatment OAM:  OAM in relation to the forwarding
+      treatment of user data packets, as for example QoS treatment.
+
+      Equal-Forwarding-Treatment OAM:
          The OAM packets receive the same forwarding (e.g., QoS)
          treatment as user data packets.  This was sometimes referred to
          as "in-band".
@@ -270,17 +274,17 @@ Internet-Draft             Characterizing OAM                 April 2025
    Security is improved when terms are used with precision, and their
    definitions are unambiguous.
 
-4.  IANA Considerations
-
-   This document has no IANA actions.
 
 
 
-
-Pignataro, et al.        Expires 12 October 2025                [Page 5]
+Pignataro, et al.        Expires 24 October 2025                [Page 5]
 
 Internet-Draft             Characterizing OAM                 April 2025
 
+
+4.  IANA Considerations
+
+   This document has no IANA actions.
 
 5.  Acknowledgements
 
@@ -326,18 +330,18 @@ Internet-Draft             Characterizing OAM                 April 2025
               <https://datatracker.ietf.org/doc/html/draft-kumar-ippm-
               ifa-08>.
 
-   [I-D.song-opsawg-ifit-framework]
-              Song, H., Qin, F., Chen, H., Jin, J., and J. Shin,
-              "Framework for In-situ Flow Information Telemetry", Work
-              in Progress, Internet-Draft, draft-song-opsawg-ifit-
 
 
 
-Pignataro, et al.        Expires 12 October 2025                [Page 6]
+Pignataro, et al.        Expires 24 October 2025                [Page 6]
 
 Internet-Draft             Characterizing OAM                 April 2025
 
 
+   [I-D.song-opsawg-ifit-framework]
+              Song, H., Qin, F., Chen, H., Jin, J., and J. Shin,
+              "Framework for In-situ Flow Information Telemetry", Work
+              in Progress, Internet-Draft, draft-song-opsawg-ifit-
               framework-21, 23 October 2023,
               <https://datatracker.ietf.org/doc/html/draft-song-opsawg-
               ifit-framework-21>.
@@ -380,19 +384,20 @@ Internet-Draft             Characterizing OAM                 April 2025
               DOI 10.17487/RFC8029, March 2017,
               <https://www.rfc-editor.org/info/rfc8029>.
 
+
+
+
+
+
+Pignataro, et al.        Expires 24 October 2025                [Page 7]
+
+Internet-Draft             Characterizing OAM                 April 2025
+
+
    [RFC9197]  Brockners, F., Ed., Bhandari, S., Ed., and T. Mizrahi,
               Ed., "Data Fields for In Situ Operations, Administration,
               and Maintenance (IOAM)", RFC 9197, DOI 10.17487/RFC9197,
               May 2022, <https://www.rfc-editor.org/info/rfc9197>.
-
-
-
-
-
-Pignataro, et al.        Expires 12 October 2025                [Page 7]
-
-Internet-Draft             Characterizing OAM                 April 2025
-
 
    [RFC9232]  Song, H., Qin, F., Martinez-Julia, P., Ciavaglia, L., and
               A. Wang, "Network Telemetry Framework", RFC 9232,
@@ -440,9 +445,4 @@ Authors' Addresses
 
 
 
-
-
-
-
-
-Pignataro, et al.        Expires 12 October 2025                [Page 8]
+Pignataro, et al.        Expires 24 October 2025                [Page 8]

--- a/draft-ietf-opsawg-oam-characterization.xml
+++ b/draft-ietf-opsawg-oam-characterization.xml
@@ -177,7 +177,13 @@
               <t hangText="Active OAM:"><br /> Depends on dedicated OAM packets.</t>
               <t hangText="Passive OAM:"><br /> Depends solely on the observation of one
       or more existing data packet streams and does not use dedicated OAM packets.</t>
-               <t hangText="Hybrid OAM:"><br /> Uses instrumentation or modification of data packets themselves. <xref target="RFC9341" /> and <xref target="RFC9197" /> are examples labeled "Hybrid OAM" under this definition.
+               <t hangText="Hybrid OAM:"><br /> Uses instrumentation or modification of data 
+                 packets themselves. Examples of protocols classified under "Hybrid OAM" 
+                 include <xref target="RFC9341" /> and <xref target="RFC9197" />. Hybrid 
+                 OAM can be implemented by piggybacking OAM-related information onto data 
+                 packets, as seen in <xref target="RFC9197" />, or by utilizing reserved 
+                 fields in the packet header or specific values of existing header fields, 
+                 as proposed in <xref target="RFC9341" />.
                </t>
             </list>
           </t>


### PR DESCRIPTION
Slightly reworded "Hybrid OAM" with the distinction between RFC9197 and RFC9341.