### PR TITLE
Added examples

### DIFF
--- a/draft-ietf-opsawg-oam-characterization.html
+++ b/draft-ietf-opsawg-oam-characterization.html
@@ -45,7 +45,7 @@
     wcwidth 0.2.13
     weasyprint 65.0
 -->
-<link href="draft-ietf-opsawg-oam-characterization.xml" rel="alternate" type="application/rfc+xml">
+<link href="draft-ietf-opsawg-oam-characterization-05.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 
@@ -1228,11 +1228,11 @@ li > p:last-of-type:only-child {
 <thead><tr>
 <td class="left">Internet-Draft</td>
 <td class="center">Characterizing OAM</td>
-<td class="right">April 2025</td>
+<td class="right">May 2025</td>
 </tr></thead>
 <tfoot><tr>
 <td class="left">Pignataro, et al.</td>
-<td class="center">Expires 24 October 2025</td>
+<td class="center">Expires 16 November 2025</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1248,12 +1248,12 @@ li > p:last-of-type:only-child {
 <a href="https://www.rfc-editor.org/rfc/rfc6291" class="eref">6291</a> (if approved)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2025-04-22" class="published">22 April 2025</time>
+<time datetime="2025-05-15" class="published">15 May 2025</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Best Current Practice</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2025-10-24">24 October 2025</time></dd>
+<dd class="expires"><time datetime="2025-11-16">16 November 2025</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1309,7 +1309,7 @@ li > p:last-of-type:only-child {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 24 October 2025.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 16 November 2025.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1436,8 +1436,14 @@ li > p:last-of-type:only-child {
 </dd>
           <dd class="break"></dd>
 <dt id="section-2.1-2.5"></dt>
-          <dd style="margin-left: 1.5em" id="section-2.1-2.6">
-            <span>[<a href="#RFC6669" class="cite xref">RFC6669</a>]</span>, Section 2 fourth bullet, gives an example of "Path-Congruent OAM", and further describes that the OAM Packets "share their fate with data packets."<a href="#section-2.1-2.6" class="pilcrow">¶</a>
+          <dd style="margin-left: 1.5em" id="section-2.1-2.6">An example of "Path-Congruent OAM" is the Virtual 
+ Circuit Connectivity Verification (VCCV), described
+ is Section 6 of <span>[<a href="#RFC5085" class="cite xref">RFC5085</a>]</span> as "The VCCV
+        message travels in-band with the Session and follows the exact same
+        path as the user data for the session". Thus,
+ the term "in-band" in <span>[<a href="#RFC5085" class="cite xref">RFC5085</a>]</span> refers to using the same path as the user data.
+ This term is also used in Section 2 of <span>[<a href="#RFC6669" class="cite xref">RFC6669</a>]</span> with the same meaning,
+        and the word "congruent" is mentioned as synonymous.<a href="#section-2.1-2.6" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt id="section-2.1-2.7">Active, Passive, Hybrid, and In-Packet OAM</dt>
@@ -1465,13 +1471,16 @@ li > p:last-of-type:only-child {
               <dd class="break"></dd>
 <dt id="section-2.1-2.10.2.5">Hybrid OAM:</dt>
               <dd style="margin-left: 1.5em" id="section-2.1-2.10.2.6">
-                <br> Uses instrumentation or modification of data 
-                 packets themselves. Examples of protocols classified under "Hybrid OAM" 
-                 include <span>[<a href="#RFC9341" class="cite xref">RFC9341</a>]</span> and <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span>. Hybrid 
+                <br> Uses instrumentation or modification of the data 
+                 stream. Examples of protocols classified as "Hybrid OAM" 
+                 include <span>[<a href="#RFC9341" class="cite xref">RFC9341</a>]</span>, <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span>, and <span>[<a href="#RFC6374" class="cite xref">RFC6374</a>]</span>. Hybrid 
                  OAM can be implemented by piggybacking OAM-related information onto data 
-                 packets, as seen in <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span>, or by utilizing reserved 
+                 packets, as described in <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span>, or by utilizing reserved 
                  fields in the packet header or specific values of existing header fields, 
-                 as proposed in <span>[<a href="#RFC9341" class="cite xref">RFC9341</a>]</span>.<a href="#section-2.1-2.10.2.6" class="pilcrow">¶</a>
+                 as proposed in <span>[<a href="#RFC9341" class="cite xref">RFC9341</a>]</span>. Direct loss measurment <span>[<a href="#RFC6374" class="cite xref">RFC6374</a>]</span>
+          is an example of "Hybrid OAM" in which user packets are not modified by the protocol. Instead,
+          OAM packets are used to exchange information about user packet counters, allowing for
+          packet loss computation.<a href="#section-2.1-2.10.2.6" class="pilcrow">¶</a>
 </dd>
             <dd class="break"></dd>
 </dl>
@@ -1502,12 +1511,13 @@ li > p:last-of-type:only-child {
   within the packet while the packet traverses a particular network
   domain.  The term "in situ" refers to the fact that the OAM data is
   added to the data packets rather than being sent within packets
-  specifically dedicated to OAM.'<a href="#section-2.1-2.18" class="pilcrow">¶</a>
+  specifically dedicated to OAM.' On the other hand, direct loss measurement <span>[<a href="#RFC6374" class="cite xref">RFC6374</a>]</span>
+  is an example of "Hybrid OAM" which is not classified as "In-Packet OAM".<a href="#section-2.1-2.18" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
 <dt id="section-2.1-2.19"></dt>
           <dd style="margin-left: 1.5em" id="section-2.1-2.20">
-  Initially, "in situ OAM" <span>[<a href="#IETF96-In-Band-OAM" class="cite xref">IETF96-In-Band-OAM</a>]</span> was also referred to as "In-band OAM", but was renamed due to the overloaded meaning of "in-band OAM". Further, <span>[<a href="#RFC9232" class="cite xref">RFC9232</a>]</span> also intertwines the terms "in-band" with "in situ", though <span>[<a href="#I-D.song-opsawg-ifit-framework" class="cite xref">I-D.song-opsawg-ifit-framework</a>]</span> settled on using "in Situ". Other similar uses, including <span>[<a href="#P4-INT-2.1" class="cite xref">P4-INT-2.1</a>]</span> and <span>[<a href="#I-D.kumar-ippm-ifa" class="cite xref">I-D.kumar-ippm-ifa</a>]</span>, still use variations of "in-band", "in band", or "inband".<a href="#section-2.1-2.20" class="pilcrow">¶</a>
+  Initially, "In situ OAM" <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span> was also referred to as "In-band OAM" <span>[<a href="#I-D.brockners-inband-oam-data" class="cite xref">I-D.brockners-inband-oam-data</a>]</span>, but was renamed due to the overloaded meaning of "In-band OAM". Further, <span>[<a href="#RFC9232" class="cite xref">RFC9232</a>]</span> also intertwines the terms "in-band" with "in situ", though <span>[<a href="#I-D.song-opsawg-ifit-framework" class="cite xref">I-D.song-opsawg-ifit-framework</a>]</span> settled on using "in Situ". Other similar uses, including <span>[<a href="#P4-INT-2.1" class="cite xref">P4-INT-2.1</a>]</span> and <span>[<a href="#I-D.kumar-ippm-ifa" class="cite xref">I-D.kumar-ippm-ifa</a>]</span>, still use variations of "in-band", "in band", or "inband".<a href="#section-2.1-2.20" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd><dt id="section-2.1-2.21">Packet Forwarding Treatment OAM:</dt>
           <dd style="margin-left: 1.5em" id="section-2.1-2.22"> OAM in relation to the forwarding treatment of user data packets, as for example QoS treatment.<a href="#section-2.1-2.22" class="pilcrow">¶</a>
@@ -1531,7 +1541,8 @@ li > p:last-of-type:only-child {
           <dd class="break"></dd>
 <dt id="section-2.1-2.25"></dt>
           <dd style="margin-left: 1.5em" id="section-2.1-2.26">
-For a case of either "Non-Path-Congruent OAM" or "Different-Forwarding-Treatment OAM", <span>[<a href="#RFC9551" class="cite xref">RFC9551</a>]</span> says 
+As an example, the behavior of "Equal-Forwarding-Treatment OAM" is described in <span>[<a href="#RFC9551" class="cite xref">RFC9551</a>]</span> as "it traverses the same set of links and interfaces receiving the same QoS and Packet Replication, Elimination, and Ordering Functions (PREOF) treatment as the monitored DetNet flow". This is classified in <span>[<a href="#RFC9551" class="cite xref">RFC9551</a>]</span> as "In-band OAM".
+Similarly, the property of "Different-Forwarding-Treatment OAM" can be found in the following definition in <span>[<a href="#RFC9551" class="cite xref">RFC9551</a>]</span>: 
 
 "Out-of-band OAM:
 an active OAM method whose path through the DetNet domain may not be topologically identical to the path of the monitored DetNet flow, its test packets may receive different QoS and/or PREOF treatment, or both."
@@ -1540,15 +1551,7 @@ an active OAM method whose path through the DetNet domain may not be topological
           <dd class="break"></dd>
 <dt id="section-2.1-2.27"></dt>
           <dd style="margin-left: 1.5em" id="section-2.1-2.28">Note that OAM can be classified in relation to multiple criteria, e.g., relating to both topological congruence and packet treatment, as well as other criteria, such as active, passive or hybrid <span>[<a href="#RFC7799" class="cite xref">RFC7799</a>]</span>. 
-For example, <span>[<a href="#RFC9551" class="cite xref">RFC9551</a>]</span> says 
-
-"In-band OAM: an active OAM method that is in band within
-the monitored DetNet OAM domain when it traverses the
-same set of links and interfaces receiving the same QoS and
-Packet Replication, Elimination, and Ordering Functions
-(PREOF) treatment as the monitored DetNet flow."
-
-<span>[<a href="#I-D.ietf-raw-architecture" class="cite xref">I-D.ietf-raw-architecture</a>]</span> uses similar text.<a href="#section-2.1-2.28" class="pilcrow">¶</a>
+For example, <span>[<a href="#RFC9551" class="cite xref">RFC9551</a>]</span> classifies OAM both in terms of whether it is active or passive as well as in terms of whether it receives the same treatment as the user traffic.<a href="#section-2.1-2.28" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
@@ -1560,9 +1563,9 @@ Packet Replication, Elimination, and Ordering Functions
 <a href="#section-2.2" class="section-number selfRef">2.2. </a><a href="#name-historical-uses" class="section-name selfRef">Historical Uses</a>
         </h3>
 <p id="section-2.2-1">
-              There are many examples of "in-band OAM" and "out-of-band OAM" in published RFCs. While interpreting those, it is important to understand the semantics of what "band" is a proxy for, and to be more explicit if those documents are updated. This document does not change the meaning of any terms in any prior RFCs.<a href="#section-2.2-1" class="pilcrow">¶</a></p>
+              There are many examples of "in-band OAM" and "out-of-band OAM" in published RFCs. For instance, the term "in-band" appears in both <span>[<a href="#RFC5085" class="cite xref">RFC5085</a>]</span> and <span>[<a href="#RFC9551" class="cite xref">RFC9551</a>]</span>. While the context in each of these documents is clear, the term carries different meanings in each case.<a href="#section-2.2-1" class="pilcrow">¶</a></p>
 <p id="section-2.2-2">
-              For example, <span>[<a href="#RFC5085" class="cite xref">RFC5085</a>]</span> says "as in-band traffic with the PW's data, or out-of-band", and "in-band (i.e., following the same data-plane faith as PW data)". Hence, in that specific case, the term "band" refers to the "Pseudowire data".<a href="#section-2.2-2" class="pilcrow">¶</a></p>
+   While interpreting existing documents, it is important to understand the semantics of what "band" is a proxy for, and to be more explicit if those documents are updated. This document does not change the meaning of any terms in any prior RFCs.<a href="#section-2.2-2" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
@@ -1608,6 +1611,10 @@ Packet Replication, Elimination, and Ordering Functions
 <a href="#section-6.2" class="section-number selfRef">6.2. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
         </h3>
 <dl class="references">
+<dt id="I-D.brockners-inband-oam-data">[I-D.brockners-inband-oam-data]</dt>
+        <dd>
+<span class="refAuthor">Brockners, F.</span>, <span class="refAuthor">Bhandari, S.</span>, <span class="refAuthor">Pignataro, C.</span>, and <span class="refAuthor">H. Gredler</span>, <span class="refTitle">"Data Formats for In-band OAM"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-brockners-inband-oam-data-00</span>, <time datetime="2016-07-08" class="refDate">8 July 2016</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-brockners-inband-oam-data-00">https://datatracker.ietf.org/doc/html/draft-brockners-inband-oam-data-00</a>&gt;</span>. </dd>
+<dd class="break"></dd>
 <dt id="I-D.ietf-raw-architecture">[I-D.ietf-raw-architecture]</dt>
         <dd>
 <span class="refAuthor">Thubert, P.</span>, <span class="refTitle">"Reliable and Available Wireless Architecture"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-ietf-raw-architecture-24</span>, <time datetime="2025-02-28" class="refDate">28 February 2025</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-ietf-raw-architecture-24">https://datatracker.ietf.org/doc/html/draft-ietf-raw-architecture-24</a>&gt;</span>. </dd>
@@ -1620,10 +1627,6 @@ Packet Replication, Elimination, and Ordering Functions
         <dd>
 <span class="refAuthor">Song, H.</span>, <span class="refAuthor">Qin, F.</span>, <span class="refAuthor">Chen, H.</span>, <span class="refAuthor">Jin, J.</span>, and <span class="refAuthor">J. Shin</span>, <span class="refTitle">"Framework for In-situ Flow Information Telemetry"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-song-opsawg-ifit-framework-21</span>, <time datetime="2023-10-23" class="refDate">23 October 2023</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-song-opsawg-ifit-framework-21">https://datatracker.ietf.org/doc/html/draft-song-opsawg-ifit-framework-21</a>&gt;</span>. </dd>
 <dd class="break"></dd>
-<dt id="IETF96-In-Band-OAM">[IETF96-In-Band-OAM]</dt>
-        <dd>
-<span class="refAuthor">Brockners, F.</span>, <span class="refAuthor">Bhandari, S.</span>, <span class="refAuthor">Dara, S.</span>, <span class="refAuthor">Pignataro, C.</span>, <span class="refAuthor">Gedler, H.</span>, <span class="refAuthor">Youell, S.</span>, and <span class="refAuthor">J. Leddy</span>, <span class="refTitle">"IETF 96, OPSWG: In-Band OAM"</span>, <span class="refContent">IETF-96 Proceedings</span>, <span class="seriesInfo">IETF-96 slides-96-opsawg-8.pdf</span>, <time datetime="2016-07-19" class="refDate">19 July 2016</time>, <span>&lt;<a href="https://www.ietf.org/proceedings/96/slides/slides-96-opsawg-8.pdf">https://www.ietf.org/proceedings/96/slides/slides-96-opsawg-8.pdf</a>&gt;</span>. </dd>
-<dd class="break"></dd>
 <dt id="P4-INT-2.1">[P4-INT-2.1]</dt>
         <dd>
 <span class="refTitle">"In-band Network Telemetry (INT) Dataplane Specification, Version 2.1"</span>, <time datetime="2020-11-11" class="refDate">11 November 2020</time>, <span>&lt;<a href="https://p4.org/p4-spec/docs/INT_v2_1.pdf">https://p4.org/p4-spec/docs/INT_v2_1.pdf</a>&gt;</span>. </dd>
@@ -1635,6 +1638,10 @@ Packet Replication, Elimination, and Ordering Functions
 <dt id="RFC5085">[RFC5085]</dt>
         <dd>
 <span class="refAuthor">Nadeau, T., Ed.</span> and <span class="refAuthor">C. Pignataro, Ed.</span>, <span class="refTitle">"Pseudowire Virtual Circuit Connectivity Verification (VCCV): A Control Channel for Pseudowires"</span>, <span class="seriesInfo">RFC 5085</span>, <span class="seriesInfo">DOI 10.17487/RFC5085</span>, <time datetime="2007-12" class="refDate">December 2007</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc5085">https://www.rfc-editor.org/info/rfc5085</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC6374">[RFC6374]</dt>
+        <dd>
+<span class="refAuthor">Frost, D.</span> and <span class="refAuthor">S. Bryant</span>, <span class="refTitle">"Packet Loss and Delay Measurement for MPLS Networks"</span>, <span class="seriesInfo">RFC 6374</span>, <span class="seriesInfo">DOI 10.17487/RFC6374</span>, <time datetime="2011-09" class="refDate">September 2011</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc6374">https://www.rfc-editor.org/info/rfc6374</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="RFC6669">[RFC6669]</dt>
         <dd>

--- a/draft-ietf-opsawg-oam-characterization.txt
+++ b/draft-ietf-opsawg-oam-characterization.txt
@@ -6,9 +6,9 @@ OPS Area Working Group                                      C. Pignataro
 Internet-Draft                                      Blue Fern Consulting
 Updates: 6291 (if approved)                                    A. Farrel
 Intended status: Best Current Practice                Old Dog Consulting
-Expires: 24 October 2025                                      T. Mizrahi
+Expires: 16 November 2025                                     T. Mizrahi
                                                                   Huawei
-                                                           22 April 2025
+                                                             15 May 2025
 
 
                   Guidelines for Characterizing "OAM"
@@ -49,13 +49,13 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 24 October 2025.
+   This Internet-Draft will expire on 16 November 2025.
 
 
 
-Pignataro, et al.        Expires 24 October 2025                [Page 1]
+Pignataro, et al.       Expires 16 November 2025                [Page 1]
 
-Internet-Draft             Characterizing OAM                 April 2025
+Internet-Draft             Characterizing OAM                   May 2025
 
 
 Copyright Notice
@@ -77,14 +77,14 @@ Table of Contents
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
    2.  In-Band and Out-of-Band OAM . . . . . . . . . . . . . . . . .   3
      2.1.  Terminology and Guidance  . . . . . . . . . . . . . . . .   3
-     2.2.  Historical Uses . . . . . . . . . . . . . . . . . . . . .   5
-   3.  Security Considerations . . . . . . . . . . . . . . . . . . .   5
+     2.2.  Historical Uses . . . . . . . . . . . . . . . . . . . . .   6
+   3.  Security Considerations . . . . . . . . . . . . . . . . . . .   6
    4.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   6
    5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   6
    6.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   6
      6.1.  Normative References  . . . . . . . . . . . . . . . . . .   6
-     6.2.  Informative References  . . . . . . . . . . . . . . . . .   6
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .   8
+     6.2.  Informative References  . . . . . . . . . . . . . . . . .   7
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .   9
 
 1.  Introduction
 
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Pignataro, et al.        Expires 24 October 2025                [Page 2]
+Pignataro, et al.       Expires 16 November 2025                [Page 2]
 
-Internet-Draft             Characterizing OAM                 April 2025
+Internet-Draft             Characterizing OAM                   May 2025
 
 
 2.  In-Band and Out-of-Band OAM
@@ -156,19 +156,29 @@ Internet-Draft             Characterizing OAM                 April 2025
          Incongruent OAM, and was sometimes referred to as "out-of-
          band".
 
-      [RFC6669], Section 2 fourth bullet, gives an example of "Path-
-      Congruent OAM", and further describes that the OAM Packets "share
-      their fate with data packets."
+      An example of "Path-Congruent OAM" is the Virtual Circuit
+
+
+
+
+
+
+
+
+Pignataro, et al.       Expires 16 November 2025                [Page 3]
+
+Internet-Draft             Characterizing OAM                   May 2025
+
+
+      Connectivity Verification (VCCV), described is Section 6 of
+      [RFC5085] as "The VCCV message travels in-band with the Session
+      and follows the exact same path as the user data for the session".
+      Thus, the term "in-band" in [RFC5085] refers to using the same
+      path as the user data.  This term is also used in Section 2 of
+      [RFC6669] with the same meaning, and the word "congruent" is
+      mentioned as synonymous.
 
    Active, Passive, Hybrid, and In-Packet OAM
-
-
-
-
-Pignataro, et al.        Expires 24 October 2025                [Page 3]
-
-Internet-Draft             Characterizing OAM                 April 2025
-
 
       [RFC7799] provides clear definitions for active and passive
       performance assessment such that the construction of metrics and
@@ -185,13 +195,17 @@ Internet-Draft             Characterizing OAM                 April 2025
          packet streams and does not use dedicated OAM packets.
 
       Hybrid OAM:
-         Uses instrumentation or modification of data packets
-         themselves.  Examples of protocols classified under "Hybrid
-         OAM" include [RFC9341] and [RFC9197].  Hybrid OAM can be
+         Uses instrumentation or modification of the data stream.
+         Examples of protocols classified as "Hybrid OAM" include
+         [RFC9341], [RFC9197], and [RFC6374].  Hybrid OAM can be
          implemented by piggybacking OAM-related information onto data
-         packets, as seen in [RFC9197], or by utilizing reserved fields
-         in the packet header or specific values of existing header
-         fields, as proposed in [RFC9341].
+         packets, as described in [RFC9197], or by utilizing reserved
+         fields in the packet header or specific values of existing
+         header fields, as proposed in [RFC9341].  Direct loss
+         measurment [RFC6374] is an example of "Hybrid OAM" in which
+         user packets are not modified by the protocol.  Instead, OAM
+         packets are used to exchange information about user packet
+         counters, allowing for packet loss computation.
 
       This document defines the term In-Packet OAM, which is a special
       case of Hybrid OAM:
@@ -204,27 +218,30 @@ Internet-Draft             Characterizing OAM                 April 2025
       "Active OAM", since they are described as "An MPLS echo request/
       reply is a (possibly MPLS-labeled) IPv4 or IPv6 UDP packet".
 
+
+
+
+Pignataro, et al.       Expires 16 November 2025                [Page 4]
+
+Internet-Draft             Characterizing OAM                   May 2025
+
+
       In situ OAM [RFC9197] is an example of "In-Packet OAM", given that
       it: '...records OAM information within the packet while the packet
       traverses a particular network domain.  The term "in situ" refers
       to the fact that the OAM data is added to the data packets rather
-      than being sent within packets specifically dedicated to OAM.'
+      than being sent within packets specifically dedicated to OAM.'  On
+      the other hand, direct loss measurement [RFC6374] is an example of
+      "Hybrid OAM" which is not classified as "In-Packet OAM".
 
-      Initially, "in situ OAM" [IETF96-In-Band-OAM] was also referred to
-      as "In-band OAM", but was renamed due to the overloaded meaning of
-      "in-band OAM".  Further, [RFC9232] also intertwines the terms "in-
-      band" with "in situ", though [I-D.song-opsawg-ifit-framework]
-      settled on using "in Situ".  Other similar uses, including
-      [P4-INT-2.1] and [I-D.kumar-ippm-ifa], still use variations of
-      "in-band", "in band", or "inband".
-
-
-
-
-Pignataro, et al.        Expires 24 October 2025                [Page 4]
-
-Internet-Draft             Characterizing OAM                 April 2025
-
+      Initially, "In situ OAM" [RFC9197] was also referred to as "In-
+      band OAM" [I-D.brockners-inband-oam-data], but was renamed due to
+      the overloaded meaning of "In-band OAM".  Further, [RFC9232] also
+      intertwines the terms "in-band" with "in situ", though
+      [I-D.song-opsawg-ifit-framework] settled on using "in Situ".
+      Other similar uses, including [P4-INT-2.1] and
+      [I-D.kumar-ippm-ifa], still use variations of "in-band", "in
+      band", or "inband".
 
    Packet Forwarding Treatment OAM:  OAM in relation to the forwarding
       treatment of user data packets, as for example QoS treatment.
@@ -239,48 +256,54 @@ Internet-Draft             Characterizing OAM                 April 2025
          treatment as user data packets.  This was sometimes referred to
          as "out-of-band".
 
-      For a case of either "Non-Path-Congruent OAM" or "Different-
-      Forwarding-Treatment OAM", [RFC9551] says "Out-of-band OAM: an
-      active OAM method whose path through the DetNet domain may not be
-      topologically identical to the path of the monitored DetNet flow,
-      its test packets may receive different QoS and/or PREOF treatment,
-      or both."  [I-D.ietf-raw-architecture] uses similar text.
+      As an example, the behavior of "Equal-Forwarding-Treatment OAM" is
+      described in [RFC9551] as "it traverses the same set of links and
+      interfaces receiving the same QoS and Packet Replication,
+      Elimination, and Ordering Functions (PREOF) treatment as the
+      monitored DetNet flow".  This is classified in [RFC9551] as "In-
+      band OAM".  Similarly, the property of "Different-Forwarding-
+      Treatment OAM" can be found in the following definition in
+      [RFC9551]: "Out-of-band OAM: an active OAM method whose path
+      through the DetNet domain may not be topologically identical to
+      the path of the monitored DetNet flow, its test packets may
+      receive different QoS and/or PREOF treatment, or both."
+      [I-D.ietf-raw-architecture] uses similar text.
 
       Note that OAM can be classified in relation to multiple criteria,
+
+
+
+
+
+
+
+Pignataro, et al.       Expires 16 November 2025                [Page 5]
+
+Internet-Draft             Characterizing OAM                   May 2025
+
+
       e.g., relating to both topological congruence and packet
       treatment, as well as other criteria, such as active, passive or
-      hybrid [RFC7799].  For example, [RFC9551] says "In-band OAM: an
-      active OAM method that is in band within the monitored DetNet OAM
-      domain when it traverses the same set of links and interfaces
-      receiving the same QoS and Packet Replication, Elimination, and
-      Ordering Functions (PREOF) treatment as the monitored DetNet
-      flow."  [I-D.ietf-raw-architecture] uses similar text.
+      hybrid [RFC7799].  For example, [RFC9551] classifies OAM both in
+      terms of whether it is active or passive as well as in terms of
+      whether it receives the same treatment as the user traffic.
 
 2.2.  Historical Uses
 
    There are many examples of "in-band OAM" and "out-of-band OAM" in
-   published RFCs.  While interpreting those, it is important to
-   understand the semantics of what "band" is a proxy for, and to be
-   more explicit if those documents are updated.  This document does not
-   change the meaning of any terms in any prior RFCs.
+   published RFCs.  For instance, the term "in-band" appears in both
+   [RFC5085] and [RFC9551].  While the context in each of these
+   documents is clear, the term carries different meanings in each case.
 
-   For example, [RFC5085] says "as in-band traffic with the PW's data,
-   or out-of-band", and "in-band (i.e., following the same data-plane
-   faith as PW data)".  Hence, in that specific case, the term "band"
-   refers to the "Pseudowire data".
+   While interpreting existing documents, it is important to understand
+   the semantics of what "band" is a proxy for, and to be more explicit
+   if those documents are updated.  This document does not change the
+   meaning of any terms in any prior RFCs.
 
 3.  Security Considerations
 
    Security is improved when terms are used with precision, and their
    definitions are unambiguous.
-
-
-
-
-Pignataro, et al.        Expires 24 October 2025                [Page 5]
-
-Internet-Draft             Characterizing OAM                 April 2025
-
 
 4.  IANA Considerations
 
@@ -307,6 +330,14 @@ Internet-Draft             Characterizing OAM                 April 2025
 
 6.1.  Normative References
 
+
+
+
+Pignataro, et al.       Expires 16 November 2025                [Page 6]
+
+Internet-Draft             Characterizing OAM                   May 2025
+
+
    [RFC6291]  Andersson, L., van Helvoort, H., Bonica, R., Romascanu,
               D., and S. Mansfield, "Guidelines for the Use of the "OAM"
               Acronym in the IETF", BCP 161, RFC 6291,
@@ -314,6 +345,13 @@ Internet-Draft             Characterizing OAM                 April 2025
               <https://www.rfc-editor.org/info/rfc6291>.
 
 6.2.  Informative References
+
+   [I-D.brockners-inband-oam-data]
+              Brockners, F., Bhandari, S., Pignataro, C., and H.
+              Gredler, "Data Formats for In-band OAM", Work in Progress,
+              Internet-Draft, draft-brockners-inband-oam-data-00, 8 July
+              2016, <https://datatracker.ietf.org/doc/html/draft-
+              brockners-inband-oam-data-00>.
 
    [I-D.ietf-raw-architecture]
               Thubert, P., "Reliable and Available Wireless
@@ -330,14 +368,6 @@ Internet-Draft             Characterizing OAM                 April 2025
               <https://datatracker.ietf.org/doc/html/draft-kumar-ippm-
               ifa-08>.
 
-
-
-
-Pignataro, et al.        Expires 24 October 2025                [Page 6]
-
-Internet-Draft             Characterizing OAM                 April 2025
-
-
    [I-D.song-opsawg-ifit-framework]
               Song, H., Qin, F., Chen, H., Jin, J., and J. Shin,
               "Framework for In-situ Flow Information Telemetry", Work
@@ -345,14 +375,6 @@ Internet-Draft             Characterizing OAM                 April 2025
               framework-21, 23 October 2023,
               <https://datatracker.ietf.org/doc/html/draft-song-opsawg-
               ifit-framework-21>.
-
-   [IETF96-In-Band-OAM]
-              Brockners, F., Bhandari, S., Dara, S., Pignataro, C.,
-              Gedler, H., Youell, S., and J. Leddy, "IETF 96, OPSWG: In-
-              Band OAM", IETF-96 Proceedings, IETF-96 slides-96-opsawg-
-              8.pdf, 19 July 2016,
-              <https://www.ietf.org/proceedings/96/slides/slides-96-
-              opsawg-8.pdf>.
 
    [P4-INT-2.1]
               "In-band Network Telemetry (INT) Dataplane Specification,
@@ -364,10 +386,23 @@ Internet-Draft             Characterizing OAM                 April 2025
               DOI 10.17487/RFC4733, December 2006,
               <https://www.rfc-editor.org/info/rfc4733>.
 
+
+
+
+Pignataro, et al.       Expires 16 November 2025                [Page 7]
+
+Internet-Draft             Characterizing OAM                   May 2025
+
+
    [RFC5085]  Nadeau, T., Ed. and C. Pignataro, Ed., "Pseudowire Virtual
               Circuit Connectivity Verification (VCCV): A Control
               Channel for Pseudowires", RFC 5085, DOI 10.17487/RFC5085,
               December 2007, <https://www.rfc-editor.org/info/rfc5085>.
+
+   [RFC6374]  Frost, D. and S. Bryant, "Packet Loss and Delay
+              Measurement for MPLS Networks", RFC 6374,
+              DOI 10.17487/RFC6374, September 2011,
+              <https://www.rfc-editor.org/info/rfc6374>.
 
    [RFC6669]  Sprecher, N. and L. Fang, "An Overview of the Operations,
               Administration, and Maintenance (OAM) Toolset for MPLS-
@@ -383,16 +418,6 @@ Internet-Draft             Characterizing OAM                 April 2025
               Switched (MPLS) Data-Plane Failures", RFC 8029,
               DOI 10.17487/RFC8029, March 2017,
               <https://www.rfc-editor.org/info/rfc8029>.
-
-
-
-
-
-
-Pignataro, et al.        Expires 24 October 2025                [Page 7]
-
-Internet-Draft             Characterizing OAM                 April 2025
-
 
    [RFC9197]  Brockners, F., Ed., Bhandari, S., Ed., and T. Mizrahi,
               Ed., "Data Fields for In Situ Operations, Administration,
@@ -414,6 +439,16 @@ Internet-Draft             Characterizing OAM                 April 2025
               and T. Zhou, "Alternate-Marking Method", RFC 9341,
               DOI 10.17487/RFC9341, December 2022,
               <https://www.rfc-editor.org/info/rfc9341>.
+
+
+
+
+
+
+Pignataro, et al.       Expires 16 November 2025                [Page 8]
+
+Internet-Draft             Characterizing OAM                   May 2025
+
 
    [RFC9551]  Mirsky, G., Theoleyre, F., Papadopoulos, G., Bernardos,
               CJ., Varga, B., and J. Farkas, "Framework of Operations,
@@ -445,4 +480,25 @@ Authors' Addresses
 
 
 
-Pignataro, et al.        Expires 24 October 2025                [Page 8]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Pignataro, et al.       Expires 16 November 2025                [Page 9]

--- a/draft-ietf-opsawg-oam-characterization.xml
+++ b/draft-ietf-opsawg-oam-characterization.xml
@@ -12,8 +12,7 @@
 <!ENTITY RFC.8029 SYSTEM "https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8029.xml">
 <!ENTITY RFC.9322 SYSTEM "https://bib.ietf.org/public/rfc/bibxml/reference.RFC.9322.xml">
 <!ENTITY RFC.9551 SYSTEM "https://bib.ietf.org/public/rfc/bibxml/reference.RFC.9551.xml">
-
-
+<!ENTITY RFC.6374 SYSTEM "https://bib.ietf.org/public/rfc/bibxml/reference.RFC.6374.xml">
 <!ENTITY I-D.ietf-raw-architecture SYSTEM "https://bib.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-raw-architecture.xml">
 <!ENTITY I-D.song-opsawg-ifit-framework SYSTEM "https://bib.ietf.org/public/rfc/bibxml3/reference.I-D.song-opsawg-ifit-framework.xml">
 <!ENTITY I-D.kumar-ippm-ifa SYSTEM "https://bib.ietf.org/public/rfc/bibxml3/reference.I-D.kumar-ippm-ifa.xml">
@@ -157,10 +156,15 @@
 <t hangText="Non-Path-Congruent OAM:"><br />The OAM information does not follow the exact same path as the observed data traffic. This can also be called Path-Incongruent OAM, and was sometimes referred to as "out-of-band".</t>
           </list>
 </t>
-<t><xref target="RFC6669" />, Section 2 fourth bullet, gives an example of "Path-Congruent OAM", and further describes that the OAM Packets "share their fate with data packets."</t>
-
-
-
+        <t>An example of "Path-Congruent OAM" is the Virtual 
+		Circuit Connectivity Verification (VCCV), described
+		is Section 6 of <xref target="RFC5085" /> as "The VCCV
+        message travels in-band with the Session and follows the exact same
+        path as the user data for the session". Thus,
+		the term "in-band" in <xref target="RFC5085" /> refers to using the same path as the user data.
+		This term is also used in Section 2 of <xref target="RFC6669" /> with the same meaning,
+        and the word "congruent" is mentioned as synonymous.		
+		</t>
 
 
 <t hangText="Active, Passive, Hybrid, and In-Packet OAM"></t>
@@ -177,13 +181,16 @@
               <t hangText="Active OAM:"><br /> Depends on dedicated OAM packets.</t>
               <t hangText="Passive OAM:"><br /> Depends solely on the observation of one
       or more existing data packet streams and does not use dedicated OAM packets.</t>
-               <t hangText="Hybrid OAM:"><br /> Uses instrumentation or modification of data 
-                 packets themselves. Examples of protocols classified under "Hybrid OAM" 
-                 include <xref target="RFC9341" /> and <xref target="RFC9197" />. Hybrid 
+               <t hangText="Hybrid OAM:"><br /> Uses instrumentation or modification of the data 
+                 stream. Examples of protocols classified as "Hybrid OAM" 
+                 include <xref target="RFC9341" />, <xref target="RFC9197" />, and <xref target="RFC6374" />. Hybrid 
                  OAM can be implemented by piggybacking OAM-related information onto data 
-                 packets, as seen in <xref target="RFC9197" />, or by utilizing reserved 
+                 packets, as described in <xref target="RFC9197" />, or by utilizing reserved 
                  fields in the packet header or specific values of existing header fields, 
-                 as proposed in <xref target="RFC9341" />.
+                 as proposed in <xref target="RFC9341" />. Direct loss measurment <xref target="RFC6374" />
+				         is an example of "Hybrid OAM" in which user packets are not modified by the protocol. Instead,
+				         OAM packets are used to exchange information about user packet counters, allowing for
+				         packet loss computation.
                </t>
             </list>
           </t>
@@ -204,11 +211,11 @@
   within the packet while the packet traverses a particular network
   domain.  The term "in situ" refers to the fact that the OAM data is
   added to the data packets rather than being sent within packets
-  specifically dedicated to OAM.' 
-
+  specifically dedicated to OAM.' On the other hand, direct loss measurement <xref target="RFC6374" />
+  is an example of "Hybrid OAM" which is not classified as "In-Packet OAM".
 </t>
 <t>
-  Initially, "in situ OAM" <xref target="IETF96-In-Band-OAM" /> was also referred to as "In-band OAM", but was renamed due to the overloaded meaning of "in-band OAM". Further, <xref target="RFC9232" /> also intertwines the terms "in-band" with "in situ", though <xref target="I-D.song-opsawg-ifit-framework" /> settled on using "in Situ". Other similar uses, including <xref target="P4-INT-2.1" /> and <xref target="I-D.kumar-ippm-ifa" />, still use variations of "in-band", "in band", or "inband".
+  Initially, "In situ OAM" <xref target="RFC9197" /> was also referred to as "In-band OAM" <xref target="I-D.brockners-inband-oam-data" />, but was renamed due to the overloaded meaning of "In-band OAM". Further, <xref target="RFC9232" /> also intertwines the terms "in-band" with "in situ", though <xref target="I-D.song-opsawg-ifit-framework" /> settled on using "in Situ". Other similar uses, including <xref target="P4-INT-2.1" /> and <xref target="I-D.kumar-ippm-ifa" />, still use variations of "in-band", "in band", or "inband".
 </t>
 
 <!--
@@ -227,7 +234,8 @@
           </list>
 </t>
 <t>
-For a case of either "Non-Path-Congruent OAM" or "Different-Forwarding-Treatment OAM", <xref target="RFC9551" /> says 
+As an example, the behavior of "Equal-Forwarding-Treatment OAM" is described in <xref target="RFC9551" /> as "it traverses the same set of links and interfaces receiving the same QoS and Packet Replication, Elimination, and Ordering Functions (PREOF) treatment as the monitored DetNet flow". This is classified in <xref target="RFC9551" /> as "In-band OAM".
+Similarly, the property of "Different-Forwarding-Treatment OAM" can be found in the following definition in <xref target="RFC9551" />: 
 
 "Out-of-band OAM:
 an active OAM method whose path through the DetNet domain may not be topologically identical to the path of the monitored DetNet flow, its test packets may receive different QoS and/or PREOF treatment, or both."
@@ -236,20 +244,9 @@ an active OAM method whose path through the DetNet domain may not be topological
 </t>
 
 
-
 <t>Note that OAM can be classified in relation to multiple criteria, e.g., relating to both topological congruence and packet treatment, as well as other criteria, such as active, passive or hybrid <xref target="RFC7799" />. 
-For example, <xref target="RFC9551" /> says 
-
-"In-band OAM: an active OAM method that is in band within
-the monitored DetNet OAM domain when it traverses the
-same set of links and interfaces receiving the same QoS and
-Packet Replication, Elimination, and Ordering Functions
-(PREOF) treatment as the monitored DetNet flow."
-
-<xref target="I-D.ietf-raw-architecture" /> uses similar text.
+For example, <xref target="RFC9551" /> classifies OAM both in terms of whether it is active or passive as well as in terms of whether it receives the same treatment as the user traffic. 
 </t>
-
-
 
 
           </list>
@@ -259,10 +256,10 @@ Packet Replication, Elimination, and Ordering Functions
 
     <section anchor="Historical" title="Historical Uses">
             <t>
-              There are many examples of "in-band OAM" and "out-of-band OAM" in published RFCs. While interpreting those, it is important to understand the semantics of what "band" is a proxy for, and to be more explicit if those documents are updated. This document does not change the meaning of any terms in any prior RFCs.
+              There are many examples of "in-band OAM" and "out-of-band OAM" in published RFCs. For instance, the term "in-band" appears in both <xref target="RFC5085" /> and <xref target="RFC9551" />. While the context in each of these documents is clear, the term carries different meanings in each case.
             </t>
             <t>
-              For example, <xref target="RFC5085" /> says "as in-band traffic with the PW's data, or out-of-band", and "in-band (i.e., following the same data-plane faith as PW data)". Hence, in that specific case, the term "band" refers to the "Pseudowire data".
+			  While interpreting existing documents, it is important to understand the semantics of what "band" is a proxy for, and to be more explicit if those documents are updated. This document does not change the meaning of any terms in any prior RFCs.
           </t>
 
     </section>
@@ -311,6 +308,7 @@ Packet Replication, Elimination, and Ordering Functions
       &RFC.9197;
       &RFC.9322;
       &RFC.6669;
+      &RFC.6374;
       &RFC.5085;
       &RFC.9232;
       &RFC.8029;
@@ -321,22 +319,20 @@ Packet Replication, Elimination, and Ordering Functions
       &RFC.9551;
       &I-D.kumar-ippm-ifa;
 
-      <reference anchor="IETF96-In-Band-OAM" target="https://www.ietf.org/proceedings/96/slides/slides-96-opsawg-8.pdf">
-        <front>
-            <title>IETF 96, OPSWG: In-Band OAM</title>
-            <author initials="F." surname="Brockners" fullname="Frank Brockners"></author>
-            <author initials="S." surname="Bhandari" fullname="Shwetha Bhandari"></author>
-            <author initials="S." surname="Dara" fullname="Sashank Dara"></author>
-            <author initials="C." surname="Pignataro" fullname="Carlos Pignataro"></author>
-            <author initials="H." surname="Gedler" fullname="Hannes Gedler"></author>
-            <author initials="S." surname="Youell" fullname="Steve Youell"></author>
-            <author initials="J." surname="Leddy" fullname="John Leddy"></author>
-
-            <date month="7" day="19" year="2016"/>
-        </front>
-        <refcontent>IETF-96 Proceedings</refcontent>
-        <seriesInfo name="IETF-96" value="slides-96-opsawg-8.pdf" />
-      </reference>
+<reference anchor="I-D.brockners-inband-oam-data" target="https://datatracker.ietf.org/doc/html/draft-brockners-inband-oam-data-00">
+<front>
+<title>Data Formats for In-band OAM</title>
+<author initials="F." surname="Brockners" fullname="Frank Brockners"> </author>
+<author initials="S." surname="Bhandari" fullname="Shwetha Bhandari"> </author>
+<author initials="C." surname="Pignataro" fullname="Carlos Pignataro"> </author>
+<author initials="H." surname="Gredler" fullname="Hannes Gredler"> </author>
+<date month="July" day="8" year="2016"/>
+<abstract>
+<t> In-band operation, administration and maintenance (OAM) records operational and telemetry information in the packet while the packet traverses a path between two points in the network. This document discusses the data types and data formats for in-band OAM data records. In-band OAM data records can be embedded into a variety of transports such as NSH, Segment Routing, VXLAN-GPE, native IPv6 (via extension header), or IPv4. In-band OAM is to complement current out-of-band OAM mechanisms based on ICMP or other types of probe packets. </t>
+</abstract>
+</front>
+<seriesInfo name="Internet-Draft" value="draft-brockners-inband-oam-data-00"/>
+</reference>
 
       <reference anchor="P4-INT-2.1" target="https://p4.org/p4-spec/docs/INT_v2_1.pdf">
         <front>


### PR DESCRIPTION
Added examples
Various examples and clarifications in section 2 based on Greg's comments:
- Added example of path-congruent OAM [RFC5085] and the use of the term "in-band".
- Clarified the term Hybrid OAM and added RFC6374 as an example.
- Clarified the difference between In-Packet OAM and Hybrid OAM.
- Changed the IOAM old reference from presentation to draft 00.
- Added example of equal forwarding treatment.
- Clarified Historical Uses.