### PR TITLE
Separate Terminology Section

### DIFF
--- a/draft-ietf-opsawg-oam-characterization.html
+++ b/draft-ietf-opsawg-oam-characterization.html
@@ -31,20 +31,21 @@
 <meta content="draft-ietf-opsawg-oam-characterization-06" name="ietf.draft">
 <!-- Generator version information:
   xml2rfc 3.28.1
-    Python 3.9.6
-    ConfigArgParse 1.7
+    Python 3.12.3
+    ConfigArgParse 1.7.1
     google-i18n-address 3.1.1
     intervaltree 3.1.0
     Jinja2 3.1.6
-    lxml 5.3.2
-    platformdirs 4.3.7
+    lxml 5.4.0
+    platformdirs 4.3.8
     pycountry 24.6.1
     PyYAML 6.0.2
     requests 2.32.3
-    setuptools 78.1.0
+    setuptools 80.8.0
     wcwidth 0.2.13
+    weasyprint 65.0
 -->
-<link href="draft-ietf-opsawg-oam-characterization.xml" rel="alternate" type="application/rfc+xml">
+<link href="draft-ietf-opsawg-oam-characterization-2025-06-10.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 
@@ -1231,7 +1232,7 @@ li > p:last-of-type:only-child {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Pignataro, et al.</td>
-<td class="center">Expires 10 December 2025</td>
+<td class="center">Expires 12 December 2025</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1247,12 +1248,12 @@ li > p:last-of-type:only-child {
 <a href="https://www.rfc-editor.org/rfc/rfc6291" class="eref">6291</a> (if approved)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2025-06-08" class="published">8 June 2025</time>
+<time datetime="2025-06-10" class="published">10 June 2025</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Best Current Practice</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2025-12-10">10 December 2025</time></dd>
+<dd class="expires"><time datetime="2025-12-12">12 December 2025</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1308,7 +1309,7 @@ li > p:last-of-type:only-child {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 10 December 2025.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 12 December 2025.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1341,38 +1342,47 @@ li > p:last-of-type:only-child {
             <p id="section-toc.1-1.1.1" class="keepWithNext"><a href="#section-1" class="auto internal xref">1</a>.  <a href="#name-introduction" class="internal xref">Introduction</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2">
-            <p id="section-toc.1-1.2.1"><a href="#section-2" class="auto internal xref">2</a>.  <a href="#name-in-band-and-out-of-band-oam" class="internal xref">In-Band and Out-of-Band OAM</a></p>
-<ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.1">
-                <p id="section-toc.1-1.2.2.1.1" class="keepWithNext"><a href="#section-2.1" class="auto internal xref">2.1</a>.  <a href="#name-terminology-and-guidance" class="internal xref">Terminology and Guidance</a></p>
-</li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2.2.2">
-                <p id="section-toc.1-1.2.2.2.1" class="keepWithNext"><a href="#section-2.2" class="auto internal xref">2.2</a>.  <a href="#name-historical-uses" class="internal xref">Historical Uses</a></p>
-</li>
-            </ul>
+            <p id="section-toc.1-1.2.1" class="keepWithNext"><a href="#section-2" class="auto internal xref">2</a>.  <a href="#name-in-band-and-out-of-band-oam" class="internal xref">In-Band and Out-of-Band OAM</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3">
-            <p id="section-toc.1-1.3.1"><a href="#section-3" class="auto internal xref">3</a>.  <a href="#name-security-considerations" class="internal xref">Security Considerations</a></p>
-</li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4">
-            <p id="section-toc.1-1.4.1"><a href="#section-4" class="auto internal xref">4</a>.  <a href="#name-iana-considerations" class="internal xref">IANA Considerations</a></p>
-</li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5">
-            <p id="section-toc.1-1.5.1"><a href="#section-5" class="auto internal xref">5</a>.  <a href="#name-acknowledgements" class="internal xref">Acknowledgements</a></p>
-</li>
-          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6">
-            <p id="section-toc.1-1.6.1"><a href="#section-6" class="auto internal xref">6</a>.  <a href="#name-references" class="internal xref">References</a></p>
+            <p id="section-toc.1-1.3.1"><a href="#section-3" class="auto internal xref">3</a>.  <a href="#name-terminology-and-guidance" class="internal xref">Terminology and Guidance</a></p>
 <ul class="compact toc ulBare ulEmpty">
-<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.1">
-                <p id="section-toc.1-1.6.2.1.1"><a href="#section-6.1" class="auto internal xref">6.1</a>.  <a href="#name-normative-references" class="internal xref">Normative References</a></p>
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3.2.1">
+                <p id="section-toc.1-1.3.2.1.1" class="keepWithNext"><a href="#section-3.1" class="auto internal xref">3.1</a>.  <a href="#name-path-followed-oam" class="internal xref">Path Followed OAM</a></p>
 </li>
-              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.2">
-                <p id="section-toc.1-1.6.2.2.1"><a href="#section-6.2" class="auto internal xref">6.2</a>.  <a href="#name-informative-references" class="internal xref">Informative References</a></p>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3.2.2">
+                <p id="section-toc.1-1.3.2.2.1"><a href="#section-3.2" class="auto internal xref">3.2</a>.  <a href="#name-packet-forwarding-treatment" class="internal xref">Packet Forwarding Treatment OAM</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3.2.3">
+                <p id="section-toc.1-1.3.2.3.1"><a href="#section-3.3" class="auto internal xref">3.3</a>.  <a href="#name-active-passive-hybrid-and-i" class="internal xref">Active, Passive, Hybrid, and In-Packet OAM</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3.2.4">
+                <p id="section-toc.1-1.3.2.4.1"><a href="#section-3.4" class="auto internal xref">3.4</a>.  <a href="#name-using-multiple-criteria" class="internal xref">Using Multiple Criteria</a></p>
 </li>
             </ul>
 </li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4">
+            <p id="section-toc.1-1.4.1"><a href="#section-4" class="auto internal xref">4</a>.  <a href="#name-security-considerations" class="internal xref">Security Considerations</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5">
+            <p id="section-toc.1-1.5.1"><a href="#section-5" class="auto internal xref">5</a>.  <a href="#name-iana-considerations" class="internal xref">IANA Considerations</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6">
+            <p id="section-toc.1-1.6.1"><a href="#section-6" class="auto internal xref">6</a>.  <a href="#name-acknowledgements" class="internal xref">Acknowledgements</a></p>
+</li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7">
-            <p id="section-toc.1-1.7.1"><a href="#appendix-A" class="auto internal xref"></a><a href="#name-authors-addresses" class="internal xref">Authors' Addresses</a></p>
+            <p id="section-toc.1-1.7.1"><a href="#section-7" class="auto internal xref">7</a>.  <a href="#name-references" class="internal xref">References</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.1">
+                <p id="section-toc.1-1.7.2.1.1"><a href="#section-7.1" class="auto internal xref">7.1</a>.  <a href="#name-normative-references" class="internal xref">Normative References</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7.2.2">
+                <p id="section-toc.1-1.7.2.2.1"><a href="#section-7.2" class="auto internal xref">7.2</a>.  <a href="#name-informative-references" class="internal xref">Informative References</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8">
+            <p id="section-toc.1-1.8.1"><a href="#appendix-A" class="auto internal xref"></a><a href="#name-authors-addresses" class="internal xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -1402,202 +1412,169 @@ li > p:last-of-type:only-child {
 <p id="section-2-1">
           Historically, the terms "in-band" and "out-of-band" were used extensively in radio communications as well as in telephony signaling <span>[<a href="#RFC4733" class="cite xref">RFC4733</a>]</span>. In both these cases, there is an actual "Band" (i.e., a "Channel" or "Frequency") to be within or outside.<a href="#section-2-1" class="pilcrow">¶</a></p>
 <p id="section-2-2">
-          While those terms, useful in their simplicity, continued to be broadly used to mean "within something" and "outside something", a challenge is presented for IP communications and packet-switched networks (PSNs) which do not have a "band" per se, and, in fact, have multiple "somethings" that OAM can be carried within or outside. A frequently encountered case is the use of "in-band" to mean either in-packet or on-path.<a href="#section-2-2" class="pilcrow">¶</a></p>
+          While those terms, useful in their simplicity, continued to be broadly used to mean "within something" and "outside something", a challenge is presented for IP communications and packet-switched networks (PSNs) which do not have a "band" per se, and, in fact, have multiple "somethings" that OAM traffic can be carried within or outside. A frequently encountered case is the use of "in-band" to mean either in-packet or on-path.<a href="#section-2-2" class="pilcrow">¶</a></p>
 <p id="section-2-3">
           Within the IETF, the terms "in-band" and "out-of-band" cannot be reliably understood consistently and unambiguously. Context-specific definitions of these terms are inconsistent and therefore cannot be generalized. More importantly, the terms are not self-defining to any further extent and cannot be understood by someone exposed to them for the first time, since there is no "band" in IP.<a href="#section-2-3" class="pilcrow">¶</a></p>
+<p id="section-2-4">
+              There are many examples of "in-band OAM" and "out-of-band OAM" in published RFCs. For instance, the term "in-band" appears in both <span>[<a href="#RFC5085" class="cite xref">RFC5085</a>]</span> and <span>[<a href="#RFC9551" class="cite xref">RFC9551</a>]</span>. While the context in each of these documents is clear, the term carries different meanings in each case. These two examples, as well as other examples of uses of the term "in-band" in previous documents are described throughout <a href="#terms" class="auto internal xref">Section 3</a>.<a href="#section-2-4" class="pilcrow">¶</a></p>
+<p id="section-2-5">
+   While interpreting existing documents, it is important to understand the semantics of what "band" is a proxy for, and to be more explicit if those documents are updated. This document does not change the meaning of any terms in any prior RFCs.<a href="#section-2-5" class="pilcrow">¶</a></p>
+</section>
+</div>
 <div id="terms">
-<section id="section-2.1">
-        <h3 id="name-terminology-and-guidance">
-<a href="#section-2.1" class="section-number selfRef">2.1. </a><a href="#name-terminology-and-guidance" class="section-name selfRef">Terminology and Guidance</a>
+<section id="section-3">
+      <h2 id="name-terminology-and-guidance">
+<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-terminology-and-guidance" class="section-name selfRef">Terminology and Guidance</a>
+      </h2>
+<p id="section-3-1">
+          This document recommends avoiding the terms "in-band" and "out-of-band" when referring to OAM. Instead, it encourages the use of more fine-grained and descriptive terminology. The document also presents alternative terms and definitions for use in future IETF documents referencing OAM, without precluding the use of other precise, descriptive terms that do not rely on the "-band" convention.<a href="#section-3-1" class="pilcrow">¶</a></p>
+<p id="section-3-2">
+          The terminology presented in this section classifies OAM according to three criteria: whether it follows the same path as data traffic; whether it receives the same treatment as data traffic; and whether it operates in an active, passive, or hybrid mode.<a href="#section-3-2" class="pilcrow">¶</a></p>
+<section id="section-3.1">
+        <h3 id="name-path-followed-oam">
+<a href="#section-3.1" class="section-number selfRef">3.1. </a><a href="#name-path-followed-oam" class="section-name selfRef">Path Followed OAM</a>
         </h3>
-<p id="section-2.1-1">
-          This document recommends avoiding the terms "in-band" and "out-of-band" when referring to OAM. Instead, it encourages the use of more fine-grained and descriptive terminology. The document also presents alternative terms and definitions for use in future IETF documents referencing OAM, without precluding the use of other precise, descriptive terms that do not rely on the "-band" convention.<a href="#section-2.1-1" class="pilcrow">¶</a></p>
-<p id="section-2.1-2">
-          In this document, the term "path-congruent packets" describes packets that follow the exact same path (i.e., traverse the same nodes and links) within a network. Note that this definition does not describe how the packets are treated in queues within the nodes on the path. A further concept, "equal-forwarding-treatment" describes how path-congruent packets receive the same forwarding treatment (e.g., Quality of Service (QoS)) .<a href="#section-2.1-2" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlParallel" id="section-2.1-3">
-          <dt id="section-2.1-3.1">Path OAM:</dt>
-          <dd style="margin-left: 1.5em" id="section-2.1-3.2"> OAM in relation to a path<a href="#section-2.1-3.2" class="pilcrow">¶</a>
+<span class="break"></span><dl class="dlParallel" id="section-3.1-1">
+          <dt id="section-3.1-1.1">Path-Congruent OAM:</dt>
+          <dd style="margin-left: 1.5em" id="section-3.1-1.2">
+            <br>The OAM information follows the exact same path as the observed data traffic. This was sometimes referred to as "in-band".<a href="#section-3.1-1.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-2.1-3.3"></dt>
-          <dd style="margin-left: 1.5em" id="section-2.1-3.4">
-            <span class="break"></span><dl class="dlParallel" id="section-2.1-3.4.1">
-              <dt id="section-2.1-3.4.1.1">Path-Congruent OAM:</dt>
-              <dd style="margin-left: 1.5em" id="section-2.1-3.4.1.2">
-                <br>The OAM information follows the exact same path as the observed data traffic. This was sometimes referred to as "in-band".<a href="#section-2.1-3.4.1.2" class="pilcrow">¶</a>
+<dt id="section-3.1-1.3">Non-Path-Congruent OAM:</dt>
+          <dd style="margin-left: 1.5em" id="section-3.1-1.4">
+            <br>The OAM information does not follow the exact same path as the observed data traffic. This can also be called Path-Incongruent OAM, and was sometimes referred to as "out-of-band".<a href="#section-3.1-1.4" class="pilcrow">¶</a>
 </dd>
-              <dd class="break"></dd>
-<dt id="section-2.1-3.4.1.3">Non-Path-Congruent OAM:</dt>
-              <dd style="margin-left: 1.5em" id="section-2.1-3.4.1.4">
-                <br>The OAM information does not follow the exact same path as the observed data traffic. This can also be called Path-Incongruent OAM, and was sometimes referred to as "out-of-band".<a href="#section-2.1-3.4.1.4" class="pilcrow">¶</a>
-</dd>
-            <dd class="break"></dd>
+        <dd class="break"></dd>
 </dl>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-2.1-3.5"></dt>
-          <dd style="margin-left: 1.5em" id="section-2.1-3.6">An example of "Path-Congruent OAM" is the Virtual 
+<p id="section-3.1-2">
+          In this document, the term "path-congruent packets" describes packets that follow the exact same path (i.e., traverse the same nodes and links) within a network. Note that this definition does not describe how the packets are treated in queues within the nodes on the path. A further concept, "equal-forwarding-treatment" describes how path-congruent packets receive the same forwarding treatment (e.g., Quality of Service (QoS)).<a href="#section-3.1-2" class="pilcrow">¶</a></p>
+<p id="section-3.1-3">An example of "Path-Congruent OAM" is the Virtual 
  Circuit Connectivity Verification (VCCV), described
- is Section 6 of <span>[<a href="#RFC5085" class="cite xref">RFC5085</a>]</span> as "The VCCV
+ is <span>[<a href="#RFC5085" class="cite xref">RFC5085</a>]</span> as "The VCCV
         message travels in-band with the Session and follows the exact same
         path as the user data for the session". Thus,
  the term "in-band" in <span>[<a href="#RFC5085" class="cite xref">RFC5085</a>]</span> refers to using the same path as the user data.
  This term is also used in Section 2 of <span>[<a href="#RFC6669" class="cite xref">RFC6669</a>]</span> with the same meaning,
-        and the word "congruent" is mentioned as synonymous.<a href="#section-2.1-3.6" class="pilcrow">¶</a>
+        and the word "congruent" is mentioned as synonymous.<a href="#section-3.1-3" class="pilcrow">¶</a></p>
+</section>
+<section id="section-3.2">
+        <h3 id="name-packet-forwarding-treatment">
+<a href="#section-3.2" class="section-number selfRef">3.2. </a><a href="#name-packet-forwarding-treatment" class="section-name selfRef">Packet Forwarding Treatment OAM</a>
+        </h3>
+<span class="break"></span><dl class="dlParallel" id="section-3.2-1">
+          <dt id="section-3.2-1.1">Equal-Forwarding-Treatment OAM:</dt>
+          <dd style="margin-left: 1.5em" id="section-3.2-1.2">
+            <br>The OAM packets receive the same forwarding (e.g., QoS) treatment as user data packets. This was sometimes referred to as "in-band".<a href="#section-3.2-1.2" class="pilcrow">¶</a>
 </dd>
           <dd class="break"></dd>
-<dt id="section-2.1-3.7">Active, Passive, Hybrid, and In-Packet OAM</dt>
-          <dd style="margin-left: 1.5em" id="section-2.1-3.8"></dd>
-          <dd class="break"></dd>
-<dt id="section-2.1-3.9"></dt>
-          <dd style="margin-left: 1.5em" id="section-2.1-3.10">
-            <p id="section-2.1-3.10.1"><span>[<a href="#RFC7799" class="cite xref">RFC7799</a>]</span> provides clear definitions for active and passive
+<dt id="section-3.2-1.3">Different-Forwarding-Treatment OAM:</dt>
+          <dd style="margin-left: 1.5em" id="section-3.2-1.4">
+            <br>The OAM packets receive different forwarding (e.g., QoS) treatment as user data packets. This was sometimes referred to as "out-of-band".<a href="#section-3.2-1.4" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+</dl>
+<p id="section-3.2-2">
+As an example, the behavior of "Equal-Forwarding-Treatment OAM" is described in <span>[<a href="#RFC9551" class="cite xref">RFC9551</a>]</span> as "it traverses the same set of links and interfaces receiving the same QoS and Packet Replication, Elimination, and Ordering Functions (PREOF) treatment as the monitored DetNet flow". This is classified in <span>[<a href="#RFC9551" class="cite xref">RFC9551</a>]</span> as "In-band OAM".
+Similarly, the property of "Different-Forwarding-Treatment OAM" can be found in the following definition in <span>[<a href="#RFC9551" class="cite xref">RFC9551</a>]</span>: 
+
+"Out-of-band OAM:
+an active OAM method whose path through the DetNet domain may not be topologically identical to the path of the monitored DetNet flow, its test packets may receive different QoS and/or PREOF treatment, or both."
+<span>[<a href="#I-D.ietf-raw-architecture" class="cite xref">I-D.ietf-raw-architecture</a>]</span> uses similar text.<a href="#section-3.2-2" class="pilcrow">¶</a></p>
+</section>
+<section id="section-3.3">
+        <h3 id="name-active-passive-hybrid-and-i">
+<a href="#section-3.3" class="section-number selfRef">3.3. </a><a href="#name-active-passive-hybrid-and-i" class="section-name selfRef">Active, Passive, Hybrid, and In-Packet OAM</a>
+        </h3>
+<p id="section-3.3-1">
+               <span>[<a href="#RFC7799" class="cite xref">RFC7799</a>]</span> provides clear definitions for active and passive
                performance assessment such that the construction of metrics and
                methods can be described as either "Active" or "Passive".  Even
                though <span>[<a href="#RFC7799" class="cite xref">RFC7799</a>]</span> does not include the specific terms "Active",
                "Passive", or "Hybrid" as modifiers of "OAM", the following terms
-               are used in many RFCs and are provided here for clarity.<a href="#section-2.1-3.10.1" class="pilcrow">¶</a></p>
-<span class="break"></span><dl class="dlParallel" id="section-2.1-3.10.2">
-              <dt id="section-2.1-3.10.2.1">Active OAM:</dt>
-              <dd style="margin-left: 1.5em" id="section-2.1-3.10.2.2">
-                <br> Depends on dedicated OAM packets.<a href="#section-2.1-3.10.2.2" class="pilcrow">¶</a>
+               are used in many RFCs and are provided here for clarity.<a href="#section-3.3-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlParallel" id="section-3.3-2">
+          <dt id="section-3.3-2.1">Active OAM:</dt>
+          <dd style="margin-left: 1.5em" id="section-3.3-2.2">
+            <br> Depends on dedicated OAM packets.<a href="#section-3.3-2.2" class="pilcrow">¶</a>
 </dd>
-              <dd class="break"></dd>
-<dt id="section-2.1-3.10.2.3">Passive OAM:</dt>
-              <dd style="margin-left: 1.5em" id="section-2.1-3.10.2.4">
-                <br> Depends solely on the observation of one
-      or more existing data packet streams and does not use dedicated OAM packets.<a href="#section-2.1-3.10.2.4" class="pilcrow">¶</a>
+          <dd class="break"></dd>
+<dt id="section-3.3-2.3">Passive OAM:</dt>
+          <dd style="margin-left: 1.5em" id="section-3.3-2.4">
+            <br> Depends solely on the observation of one
+      or more existing data packet streams and does not use dedicated OAM packets.<a href="#section-3.3-2.4" class="pilcrow">¶</a>
 </dd>
-              <dd class="break"></dd>
-<dt id="section-2.1-3.10.2.5">Hybrid OAM:</dt>
-              <dd style="margin-left: 1.5em" id="section-2.1-3.10.2.6">
-                <br> Uses instrumentation or modification of the data 
+          <dd class="break"></dd>
+<dt id="section-3.3-2.5">Hybrid OAM:</dt>
+          <dd style="margin-left: 1.5em" id="section-3.3-2.6">
+            <br> Uses augmentation or modification of the packet 
                  stream. Examples of protocols classified as "Hybrid OAM" 
                  include <span>[<a href="#RFC9341" class="cite xref">RFC9341</a>]</span>, <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span>, and <span>[<a href="#RFC6374" class="cite xref">RFC6374</a>]</span>. Hybrid 
                  OAM can be implemented by piggybacking OAM-related information onto data 
                  packets, as described in <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span>, or by utilizing reserved 
                  fields in the packet header or specific values of existing header fields, 
                  as proposed in <span>[<a href="#RFC9341" class="cite xref">RFC9341</a>]</span>. Direct loss measurment <span>[<a href="#RFC6374" class="cite xref">RFC6374</a>]</span>
-          is an example of "Hybrid OAM" in which user packets are not modified by the protocol. Instead,
-          OAM packets are used to exchange information about user packet counters, allowing for
-          packet loss computation.<a href="#section-2.1-3.10.2.6" class="pilcrow">¶</a>
-</dd>
-            <dd class="break"></dd>
-</dl>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-2.1-3.11"></dt>
-          <dd style="margin-left: 1.5em" id="section-2.1-3.12">This document defines the term In-Packet OAM, which is a special case of Hybrid OAM:<a href="#section-2.1-3.12" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-2.1-3.13"></dt>
-          <dd style="margin-left: 1.5em" id="section-2.1-3.14">
-            <span class="break"></span><dl class="dlParallel" id="section-2.1-3.14.1">
-              <dt id="section-2.1-3.14.1.1">In-Packet OAM:</dt>
-              <dd style="margin-left: 1.5em" id="section-2.1-3.14.1.2">
-                <br>The OAM information is carried in the packets that also carry the data traffic. This was sometimes referred to as "in-band".<a href="#section-2.1-3.14.1.2" class="pilcrow">¶</a>
-</dd>
-            <dd class="break"></dd>
-</dl>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-2.1-3.15"></dt>
-          <dd style="margin-left: 1.5em" id="section-2.1-3.16">
-  The MPLS echo request/reply messages <span>[<a href="#RFC8029" class="cite xref">RFC8029</a>]</span> are an example of "Active OAM", since they are described as "An MPLS echo request/reply is a (possibly MPLS-labeled) IPv4 or IPv6 UDP packet".<a href="#section-2.1-3.16" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-2.1-3.17"></dt>
-          <dd style="margin-left: 1.5em" id="section-2.1-3.18">In situ OAM <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span> is an example of "In-Packet OAM", given that it: '...records OAM information
-  within the packet while the packet traverses a particular network
-  domain.  The term "in situ" refers to the fact that the OAM data is
-  added to the data packets rather than being sent within packets
-  specifically dedicated to OAM.' On the other hand, direct loss measurement <span>[<a href="#RFC6374" class="cite xref">RFC6374</a>]</span>
-  is an example of "Hybrid OAM" which is not classified as "In-Packet OAM".<a href="#section-2.1-3.18" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-2.1-3.19"></dt>
-          <dd style="margin-left: 1.5em" id="section-2.1-3.20">
-  Initially, "In situ OAM" <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span> was also referred to as "In-band OAM" <span>[<a href="#I-D.brockners-inband-oam-data" class="cite xref">I-D.brockners-inband-oam-data</a>]</span>, but was renamed due to the overloaded meaning of "In-band OAM". Further, <span>[<a href="#RFC9232" class="cite xref">RFC9232</a>]</span> also intertwines the terms "in-band" with "in situ", though <span>[<a href="#I-D.song-opsawg-ifit-framework" class="cite xref">I-D.song-opsawg-ifit-framework</a>]</span> settled on using "in Situ". Other similar uses, including <span>[<a href="#P4-INT-2.1" class="cite xref">P4-INT-2.1</a>]</span> and <span>[<a href="#I-D.kumar-ippm-ifa" class="cite xref">I-D.kumar-ippm-ifa</a>]</span>, still use variations of "in-band", "in band", or "inband".<a href="#section-2.1-3.20" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd><dt id="section-2.1-3.21">Packet Forwarding Treatment OAM:</dt>
-          <dd style="margin-left: 1.5em" id="section-2.1-3.22"> OAM in relation to the forwarding treatment of user data packets, as for example QoS treatment.<a href="#section-2.1-3.22" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-2.1-3.23"></dt>
-          <dd style="margin-left: 1.5em" id="section-2.1-3.24">
-            <span class="break"></span><dl class="dlParallel" id="section-2.1-3.24.1">
-              <dt id="section-2.1-3.24.1.1">Equal-Forwarding-Treatment OAM:</dt>
-              <dd style="margin-left: 1.5em" id="section-2.1-3.24.1.2">
-                <br>The OAM packets receive the same forwarding (e.g., QoS) treatment as user data packets. This was sometimes referred to as "in-band".<a href="#section-2.1-3.24.1.2" class="pilcrow">¶</a>
-</dd>
-              <dd class="break"></dd>
-<dt id="section-2.1-3.24.1.3">Different-Forwarding-Treatment OAM:</dt>
-              <dd style="margin-left: 1.5em" id="section-2.1-3.24.1.4">
-                <br>The OAM packets receive different forwarding (e.g., QoS) treatment as user data packets. This was sometimes referred to as "out-of-band".<a href="#section-2.1-3.24.1.4" class="pilcrow">¶</a>
-</dd>
-            <dd class="break"></dd>
-</dl>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-2.1-3.25"></dt>
-          <dd style="margin-left: 1.5em" id="section-2.1-3.26">
-As an example, the behavior of "Equal-Forwarding-Treatment OAM" is described in <span>[<a href="#RFC9551" class="cite xref">RFC9551</a>]</span> as "it traverses the same set of links and interfaces receiving the same QoS and Packet Replication, Elimination, and Ordering Functions (PREOF) treatment as the monitored DetNet flow". This is classified in <span>[<a href="#RFC9551" class="cite xref">RFC9551</a>]</span> as "In-band OAM".
-Similarly, the property of "Different-Forwarding-Treatment OAM" can be found in the following definition in <span>[<a href="#RFC9551" class="cite xref">RFC9551</a>]</span>: 
-
-"Out-of-band OAM:
-an active OAM method whose path through the DetNet domain may not be topologically identical to the path of the monitored DetNet flow, its test packets may receive different QoS and/or PREOF treatment, or both."
-<span>[<a href="#I-D.ietf-raw-architecture" class="cite xref">I-D.ietf-raw-architecture</a>]</span> uses similar text.<a href="#section-2.1-3.26" class="pilcrow">¶</a>
-</dd>
-          <dd class="break"></dd>
-<dt id="section-2.1-3.27"></dt>
-          <dd style="margin-left: 1.5em" id="section-2.1-3.28">Note that OAM can be classified in relation to multiple criteria, e.g., relating to both topological congruence and packet treatment, as well as other criteria, such as active, passive or hybrid <span>[<a href="#RFC7799" class="cite xref">RFC7799</a>]</span>. 
-For example, <span>[<a href="#RFC9551" class="cite xref">RFC9551</a>]</span> classifies OAM both in terms of whether it is active or passive as well as in terms of whether it receives the same treatment as the user traffic.<a href="#section-2.1-3.28" class="pilcrow">¶</a>
+  is an example of "Hybrid OAM" in which user packets are not modified by the protocol. Instead,
+  OAM packets are used to exchange information about user packet counters, allowing for
+  packet loss computation.<a href="#section-3.3-2.6" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
+<p id="section-3.3-3">This document defines the term In-Packet OAM as a more specific and narrowly scoped instance within the broader category of Hybrid OAM.<a href="#section-3.3-3" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlParallel" id="section-3.3-4">
+          <dt id="section-3.3-4.1">In-Packet OAM:</dt>
+          <dd style="margin-left: 1.5em" id="section-3.3-4.2">
+            <br>The OAM information is carried in the packets that also carry the data traffic. This was sometimes referred to as "in-band".<a href="#section-3.3-4.2" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+</dl>
+<p id="section-3.3-5">
+  The MPLS echo request/reply messages <span>[<a href="#RFC8029" class="cite xref">RFC8029</a>]</span> are an example of "Active OAM", since they are described as "An MPLS echo request/reply is a (possibly MPLS-labeled) IPv4 or IPv6 UDP packet".<a href="#section-3.3-5" class="pilcrow">¶</a></p>
+<p id="section-3.3-6">In situ OAM <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span> is an example of "Hybrid OAM" that is also "In-Packet OAM", given that it: '...records OAM information
+  within the packet while the packet traverses a particular network
+  domain.  The term "in situ" refers to the fact that the OAM data is
+  added to the data packets rather than being sent within packets
+  specifically dedicated to OAM.'<a href="#section-3.3-6" class="pilcrow">¶</a></p>
+<p id="section-3.3-7">An example of "Hybrid OAM" which is not classified as "In-Packet OAM" is Direct loss measurement <span>[<a href="#RFC6374" class="cite xref">RFC6374</a>]</span>.<a href="#section-3.3-7" class="pilcrow">¶</a></p>
+<p id="section-3.3-8">
+  Initially, "In situ OAM" <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span> was also referred to as "In-band OAM", but was renamed due to the overloaded meaning of "In-band OAM". Further, <span>[<a href="#RFC9232" class="cite xref">RFC9232</a>]</span> also intertwines the terms "in-band" with "in situ", though <span>[<a href="#I-D.song-opsawg-ifit-framework" class="cite xref">I-D.song-opsawg-ifit-framework</a>]</span> settled on using "in Situ". Other similar uses, including <span>[<a href="#P4-INT-2.1" class="cite xref">P4-INT-2.1</a>]</span> and <span>[<a href="#I-D.kumar-ippm-ifa" class="cite xref">I-D.kumar-ippm-ifa</a>]</span>, still use variations of "in-band", "in band", or "inband".<a href="#section-3.3-8" class="pilcrow">¶</a></p>
 </section>
-</div>
-<div id="Historical">
-<section id="section-2.2">
-        <h3 id="name-historical-uses">
-<a href="#section-2.2" class="section-number selfRef">2.2. </a><a href="#name-historical-uses" class="section-name selfRef">Historical Uses</a>
+<section id="section-3.4">
+        <h3 id="name-using-multiple-criteria">
+<a href="#section-3.4" class="section-number selfRef">3.4. </a><a href="#name-using-multiple-criteria" class="section-name selfRef">Using Multiple Criteria</a>
         </h3>
-<p id="section-2.2-1">
-              There are many examples of "in-band OAM" and "out-of-band OAM" in published RFCs. For instance, the term "in-band" appears in both <span>[<a href="#RFC5085" class="cite xref">RFC5085</a>]</span> and <span>[<a href="#RFC9551" class="cite xref">RFC9551</a>]</span>. While the context in each of these documents is clear, the term carries different meanings in each case.<a href="#section-2.2-1" class="pilcrow">¶</a></p>
-<p id="section-2.2-2">
-   While interpreting existing documents, it is important to understand the semantics of what "band" is a proxy for, and to be more explicit if those documents are updated. This document does not change the meaning of any terms in any prior RFCs.<a href="#section-2.2-2" class="pilcrow">¶</a></p>
+<p id="section-3.4-1">Note that OAM can be classified in relation to multiple criteria, e.g., relating to both topological congruence and packet treatment, as well as other criteria, such as active, passive or hybrid <span>[<a href="#RFC7799" class="cite xref">RFC7799</a>]</span>. 
+For example, <span>[<a href="#RFC9551" class="cite xref">RFC9551</a>]</span> classifies OAM both in terms of whether it is active or passive as well as in terms of whether it receives the same treatment as the user traffic.<a href="#section-3.4-1" class="pilcrow">¶</a></p>
+</section>
 </section>
 </div>
-</section>
-</div>
-<section id="section-3">
-      <h2 id="name-security-considerations">
-<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
-      </h2>
-<p id="section-3-1">Security is improved when terms are used with precision, and their definitions are unambiguous.<a href="#section-3-1" class="pilcrow">¶</a></p>
-</section>
 <section id="section-4">
-      <h2 id="name-iana-considerations">
-<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
+      <h2 id="name-security-considerations">
+<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
       </h2>
-<p id="section-4-1">This document has no IANA actions.<a href="#section-4-1" class="pilcrow">¶</a></p>
+<p id="section-4-1">Security is improved when terms are used with precision, and their definitions are unambiguous.<a href="#section-4-1" class="pilcrow">¶</a></p>
 </section>
 <section id="section-5">
-      <h2 id="name-acknowledgements">
-<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
+      <h2 id="name-iana-considerations">
+<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
       </h2>
-<p id="section-5-1">
-        The creation of this document was triggered when observing one of many on-mailing-list discussions of what these terms mean, and how to abbreviate them. Participants on that mailing thread include, alphabetically: Adrian Farrel, Alexander Vainshtein, Florian Kauer, Frank Brockners, Greg Mirsky, Italo Busi, Loa Andersson, Med Boucadair, Michael Richardson, Quan Xiong, Stewart Bryant, Tom Petch, Eduard Vasilenko, and Xiao Min.<a href="#section-5-1" class="pilcrow">¶</a></p>
-<p id="section-5-2">
-        The authors wish to thank, chronologically, Hesham Elbakoury, Michael Richardson, Stewart Bryant, Greg Mirsky, Med Boucadair, Loa Andersson, Thomas Graf, Alex Huang Feng, Xiao Min, Dhruv Dhody, Henk Birkholz, Alex Huang Feng, Tom Petch, Roni Even, and Tim Chown for their thorough review and useful feedback comments that greatly improved this document.<a href="#section-5-2" class="pilcrow">¶</a></p>
+<p id="section-5-1">This document has no IANA actions.<a href="#section-5-1" class="pilcrow">¶</a></p>
 </section>
 <section id="section-6">
-      <h2 id="name-references">
-<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-references" class="section-name selfRef">References</a>
+      <h2 id="name-acknowledgements">
+<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
       </h2>
-<section id="section-6.1">
+<p id="section-6-1">
+        The creation of this document was triggered when observing one of many on-mailing-list discussions of what these terms mean, and how to abbreviate them. Participants on that mailing thread include, alphabetically: Adrian Farrel, Alexander Vainshtein, Florian Kauer, Frank Brockners, Greg Mirsky, Italo Busi, Loa Andersson, Med Boucadair, Michael Richardson, Quan Xiong, Stewart Bryant, Tom Petch, Eduard Vasilenko, and Xiao Min.<a href="#section-6-1" class="pilcrow">¶</a></p>
+<p id="section-6-2">
+        The authors wish to thank, chronologically, Hesham Elbakoury, Michael Richardson, Stewart Bryant, Greg Mirsky, Med Boucadair, Loa Andersson, Thomas Graf, Alex Huang Feng, Xiao Min, Dhruv Dhody, Henk Birkholz, Alex Huang Feng, Tom Petch, Roni Even, and Tim Chown for their thorough review and useful feedback comments that greatly improved this document.<a href="#section-6-2" class="pilcrow">¶</a></p>
+</section>
+<section id="section-7">
+      <h2 id="name-references">
+<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-references" class="section-name selfRef">References</a>
+      </h2>
+<section id="section-7.1">
         <h3 id="name-normative-references">
-<a href="#section-6.1" class="section-number selfRef">6.1. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
+<a href="#section-7.1" class="section-number selfRef">7.1. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
         </h3>
 <dl class="references">
 <dt id="RFC6291">[RFC6291]</dt>
@@ -1606,15 +1583,11 @@ For example, <span>[<a href="#RFC9551" class="cite xref">RFC9551</a>]</span> cla
 <dd class="break"></dd>
 </dl>
 </section>
-<section id="section-6.2">
+<section id="section-7.2">
         <h3 id="name-informative-references">
-<a href="#section-6.2" class="section-number selfRef">6.2. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
+<a href="#section-7.2" class="section-number selfRef">7.2. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
         </h3>
 <dl class="references">
-<dt id="I-D.brockners-inband-oam-data">[I-D.brockners-inband-oam-data]</dt>
-        <dd>
-<span class="refAuthor">Brockners, F.</span>, <span class="refAuthor">Bhandari, S.</span>, <span class="refAuthor">Pignataro, C.</span>, and <span class="refAuthor">H. Gredler</span>, <span class="refTitle">"Data Formats for In-band OAM"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-brockners-inband-oam-data-00</span>, <time datetime="2016-07-08" class="refDate">8 July 2016</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-brockners-inband-oam-data-00">https://datatracker.ietf.org/doc/html/draft-brockners-inband-oam-data-00</a>&gt;</span>. </dd>
-<dd class="break"></dd>
 <dt id="I-D.ietf-raw-architecture">[I-D.ietf-raw-architecture]</dt>
         <dd>
 <span class="refAuthor">Thubert, P.</span>, <span class="refTitle">"Reliable and Available Wireless Architecture"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-ietf-raw-architecture-24</span>, <time datetime="2025-02-28" class="refDate">28 February 2025</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-ietf-raw-architecture-24">https://datatracker.ietf.org/doc/html/draft-ietf-raw-architecture-24</a>&gt;</span>. </dd>

--- a/draft-ietf-opsawg-oam-characterization.txt
+++ b/draft-ietf-opsawg-oam-characterization.txt
@@ -6,9 +6,9 @@ OPS Area Working Group                                      C. Pignataro
 Internet-Draft                                      Blue Fern Consulting
 Updates: 6291 (if approved)                                    A. Farrel
 Intended status: Best Current Practice                Old Dog Consulting
-Expires: 10 December 2025                                     T. Mizrahi
+Expires: 12 December 2025                                     T. Mizrahi
                                                                   Huawei
-                                                             8 June 2025
+                                                            10 June 2025
 
 
                   Guidelines for Characterizing "OAM"
@@ -49,11 +49,11 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 10 December 2025.
+   This Internet-Draft will expire on 12 December 2025.
 
 
 
-Pignataro, et al.       Expires 10 December 2025                [Page 1]
+Pignataro, et al.       Expires 12 December 2025                [Page 1]
 
 Internet-Draft             Characterizing OAM                  June 2025
 
@@ -76,14 +76,17 @@ Table of Contents
 
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
    2.  In-Band and Out-of-Band OAM . . . . . . . . . . . . . . . . .   3
-     2.1.  Terminology and Guidance  . . . . . . . . . . . . . . . .   3
-     2.2.  Historical Uses . . . . . . . . . . . . . . . . . . . . .   6
-   3.  Security Considerations . . . . . . . . . . . . . . . . . . .   6
-   4.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   6
-   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   6
-   6.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   7
-     6.1.  Normative References  . . . . . . . . . . . . . . . . . .   7
-     6.2.  Informative References  . . . . . . . . . . . . . . . . .   7
+   3.  Terminology and Guidance  . . . . . . . . . . . . . . . . . .   3
+     3.1.  Path Followed OAM . . . . . . . . . . . . . . . . . . . .   4
+     3.2.  Packet Forwarding Treatment OAM . . . . . . . . . . . . .   4
+     3.3.  Active, Passive, Hybrid, and In-Packet OAM  . . . . . . .   5
+     3.4.  Using Multiple Criteria . . . . . . . . . . . . . . . . .   6
+   4.  Security Considerations . . . . . . . . . . . . . . . . . . .   6
+   5.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   6
+   6.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   6
+   7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   7
+     7.1.  Normative References  . . . . . . . . . . . . . . . . . .   7
+     7.2.  Informative References  . . . . . . . . . . . . . . . . .   7
    Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .   9
 
 1.  Introduction
@@ -101,18 +104,19 @@ Table of Contents
    the OAM abbreviation, and lays out guidelines for their use in future
    IETF work to achieve consistent and unambiguous characterization.
 
-   This document updates [RFC6291] by adding to the guidelines for the
-   use of the term "OAM".  It does not modify any other part of
-   [RFC6291].
 
 
 
 
 
-Pignataro, et al.       Expires 10 December 2025                [Page 2]
+Pignataro, et al.       Expires 12 December 2025                [Page 2]
 
 Internet-Draft             Characterizing OAM                  June 2025
 
+
+   This document updates [RFC6291] by adding to the guidelines for the
+   use of the term "OAM".  It does not modify any other part of
+   [RFC6291].
 
 2.  In-Band and Out-of-Band OAM
 
@@ -125,9 +129,9 @@ Internet-Draft             Characterizing OAM                  June 2025
    broadly used to mean "within something" and "outside something", a
    challenge is presented for IP communications and packet-switched
    networks (PSNs) which do not have a "band" per se, and, in fact, have
-   multiple "somethings" that OAM can be carried within or outside.  A
-   frequently encountered case is the use of "in-band" to mean either
-   in-packet or on-path.
+   multiple "somethings" that OAM traffic can be carried within or
+   outside.  A frequently encountered case is the use of "in-band" to
+   mean either in-packet or on-path.
 
    Within the IETF, the terms "in-band" and "out-of-band" cannot be
    reliably understood consistently and unambiguously.  Context-specific
@@ -136,7 +140,19 @@ Internet-Draft             Characterizing OAM                  June 2025
    any further extent and cannot be understood by someone exposed to
    them for the first time, since there is no "band" in IP.
 
-2.1.  Terminology and Guidance
+   There are many examples of "in-band OAM" and "out-of-band OAM" in
+   published RFCs.  For instance, the term "in-band" appears in both
+   [RFC5085] and [RFC9551].  While the context in each of these
+   documents is clear, the term carries different meanings in each case.
+   These two examples, as well as other examples of uses of the term
+   "in-band" in previous documents are described throughout Section 3.
+
+   While interpreting existing documents, it is important to understand
+   the semantics of what "band" is a proxy for, and to be more explicit
+   if those documents are updated.  This document does not change the
+   meaning of any terms in any prior RFCs.
+
+3.  Terminology and Guidance
 
    This document recommends avoiding the terms "in-band" and "out-of-
    band" when referring to OAM.  Instead, it encourages the use of more
@@ -145,184 +161,164 @@ Internet-Draft             Characterizing OAM                  June 2025
    referencing OAM, without precluding the use of other precise,
    descriptive terms that do not rely on the "-band" convention.
 
+
+
+
+
+Pignataro, et al.       Expires 12 December 2025                [Page 3]
+
+Internet-Draft             Characterizing OAM                  June 2025
+
+
+   The terminology presented in this section classifies OAM according to
+   three criteria: whether it follows the same path as data traffic;
+   whether it receives the same treatment as data traffic; and whether
+   it operates in an active, passive, or hybrid mode.
+
+3.1.  Path Followed OAM
+
+   Path-Congruent OAM:
+      The OAM information follows the exact same path as the observed
+      data traffic.  This was sometimes referred to as "in-band".
+
+   Non-Path-Congruent OAM:
+      The OAM information does not follow the exact same path as the
+      observed data traffic.  This can also be called Path-Incongruent
+      OAM, and was sometimes referred to as "out-of-band".
+
    In this document, the term "path-congruent packets" describes packets
    that follow the exact same path (i.e., traverse the same nodes and
    links) within a network.  Note that this definition does not describe
    how the packets are treated in queues within the nodes on the path.
    A further concept, "equal-forwarding-treatment" describes how path-
    congruent packets receive the same forwarding treatment (e.g.,
-   Quality of Service (QoS)) .
+   Quality of Service (QoS)).
 
-   Path OAM:  OAM in relation to a path
+   An example of "Path-Congruent OAM" is the Virtual Circuit
+   Connectivity Verification (VCCV), described is [RFC5085] as "The VCCV
+   message travels in-band with the Session and follows the exact same
+   path as the user data for the session".  Thus, the term "in-band" in
+   [RFC5085] refers to using the same path as the user data.  This term
+   is also used in Section 2 of [RFC6669] with the same meaning, and the
+   word "congruent" is mentioned as synonymous.
 
-      Path-Congruent OAM:
-         The OAM information follows the exact same path as the observed
-         data traffic.  This was sometimes referred to as "in-band".
+3.2.  Packet Forwarding Treatment OAM
 
-      Non-Path-Congruent OAM:
+   Equal-Forwarding-Treatment OAM:
+      The OAM packets receive the same forwarding (e.g., QoS) treatment
+      as user data packets.  This was sometimes referred to as "in-
+      band".
+
+   Different-Forwarding-Treatment OAM:
+      The OAM packets receive different forwarding (e.g., QoS) treatment
+      as user data packets.  This was sometimes referred to as "out-of-
+      band".
+
+   As an example, the behavior of "Equal-Forwarding-Treatment OAM" is
+   described in [RFC9551] as "it traverses the same set of links and
+   interfaces receiving the same QoS and Packet Replication,
+   Elimination, and Ordering Functions (PREOF) treatment as the
 
 
 
-
-
-Pignataro, et al.       Expires 10 December 2025                [Page 3]
+Pignataro, et al.       Expires 12 December 2025                [Page 4]
 
 Internet-Draft             Characterizing OAM                  June 2025
 
 
-         The OAM information does not follow the exact same path as the
-         observed data traffic.  This can also be called Path-
-         Incongruent OAM, and was sometimes referred to as "out-of-
-         band".
+   monitored DetNet flow".  This is classified in [RFC9551] as "In-band
+   OAM".  Similarly, the property of "Different-Forwarding-Treatment
+   OAM" can be found in the following definition in [RFC9551]: "Out-of-
+   band OAM: an active OAM method whose path through the DetNet domain
+   may not be topologically identical to the path of the monitored
+   DetNet flow, its test packets may receive different QoS and/or PREOF
+   treatment, or both."  [I-D.ietf-raw-architecture] uses similar text.
 
-      An example of "Path-Congruent OAM" is the Virtual Circuit
-      Connectivity Verification (VCCV), described is Section 6 of
-      [RFC5085] as "The VCCV message travels in-band with the Session
-      and follows the exact same path as the user data for the session".
-      Thus, the term "in-band" in [RFC5085] refers to using the same
-      path as the user data.  This term is also used in Section 2 of
-      [RFC6669] with the same meaning, and the word "congruent" is
-      mentioned as synonymous.
+3.3.  Active, Passive, Hybrid, and In-Packet OAM
 
-   Active, Passive, Hybrid, and In-Packet OAM
+   [RFC7799] provides clear definitions for active and passive
+   performance assessment such that the construction of metrics and
+   methods can be described as either "Active" or "Passive".  Even
+   though [RFC7799] does not include the specific terms "Active",
+   "Passive", or "Hybrid" as modifiers of "OAM", the following terms are
+   used in many RFCs and are provided here for clarity.
 
-      [RFC7799] provides clear definitions for active and passive
-      performance assessment such that the construction of metrics and
-      methods can be described as either "Active" or "Passive".  Even
-      though [RFC7799] does not include the specific terms "Active",
-      "Passive", or "Hybrid" as modifiers of "OAM", the following terms
-      are used in many RFCs and are provided here for clarity.
+   Active OAM:
+      Depends on dedicated OAM packets.
 
-      Active OAM:
-         Depends on dedicated OAM packets.
+   Passive OAM:
+      Depends solely on the observation of one or more existing data
+      packet streams and does not use dedicated OAM packets.
 
-      Passive OAM:
-         Depends solely on the observation of one or more existing data
-         packet streams and does not use dedicated OAM packets.
+   Hybrid OAM:
+      Uses augmentation or modification of the packet stream.  Examples
+      of protocols classified as "Hybrid OAM" include [RFC9341],
+      [RFC9197], and [RFC6374].  Hybrid OAM can be implemented by
+      piggybacking OAM-related information onto data packets, as
+      described in [RFC9197], or by utilizing reserved fields in the
+      packet header or specific values of existing header fields, as
+      proposed in [RFC9341].  Direct loss measurment [RFC6374] is an
+      example of "Hybrid OAM" in which user packets are not modified by
+      the protocol.  Instead, OAM packets are used to exchange
+      information about user packet counters, allowing for packet loss
+      computation.
 
-      Hybrid OAM:
-         Uses instrumentation or modification of the data stream.
-         Examples of protocols classified as "Hybrid OAM" include
-         [RFC9341], [RFC9197], and [RFC6374].  Hybrid OAM can be
-         implemented by piggybacking OAM-related information onto data
-         packets, as described in [RFC9197], or by utilizing reserved
-         fields in the packet header or specific values of existing
-         header fields, as proposed in [RFC9341].  Direct loss
-         measurment [RFC6374] is an example of "Hybrid OAM" in which
-         user packets are not modified by the protocol.  Instead, OAM
-         packets are used to exchange information about user packet
-         counters, allowing for packet loss computation.
+   This document defines the term In-Packet OAM as a more specific and
+   narrowly scoped instance within the broader category of Hybrid OAM.
 
-      This document defines the term In-Packet OAM, which is a special
-      case of Hybrid OAM:
+   In-Packet OAM:
+      The OAM information is carried in the packets that also carry the
+      data traffic.  This was sometimes referred to as "in-band".
 
-      In-Packet OAM:
-
-
+   The MPLS echo request/reply messages [RFC8029] are an example of
+   "Active OAM", since they are described as "An MPLS echo request/reply
+   is a (possibly MPLS-labeled) IPv4 or IPv6 UDP packet".
 
 
-Pignataro, et al.       Expires 10 December 2025                [Page 4]
+
+
+Pignataro, et al.       Expires 12 December 2025                [Page 5]
 
 Internet-Draft             Characterizing OAM                  June 2025
 
 
-         The OAM information is carried in the packets that also carry
-         the data traffic.  This was sometimes referred to as "in-band".
+   In situ OAM [RFC9197] is an example of "Hybrid OAM" that is also "In-
+   Packet OAM", given that it: '...records OAM information within the
+   packet while the packet traverses a particular network domain.  The
+   term "in situ" refers to the fact that the OAM data is added to the
+   data packets rather than being sent within packets specifically
+   dedicated to OAM.'
 
-      The MPLS echo request/reply messages [RFC8029] are an example of
-      "Active OAM", since they are described as "An MPLS echo request/
-      reply is a (possibly MPLS-labeled) IPv4 or IPv6 UDP packet".
+   An example of "Hybrid OAM" which is not classified as "In-Packet OAM"
+   is Direct loss measurement [RFC6374].
 
-      In situ OAM [RFC9197] is an example of "In-Packet OAM", given that
-      it: '...records OAM information within the packet while the packet
-      traverses a particular network domain.  The term "in situ" refers
-      to the fact that the OAM data is added to the data packets rather
-      than being sent within packets specifically dedicated to OAM.'  On
-      the other hand, direct loss measurement [RFC6374] is an example of
-      "Hybrid OAM" which is not classified as "In-Packet OAM".
+   Initially, "In situ OAM" [RFC9197] was also referred to as "In-band
+   OAM", but was renamed due to the overloaded meaning of "In-band OAM".
+   Further, [RFC9232] also intertwines the terms "in-band" with "in
+   situ", though [I-D.song-opsawg-ifit-framework] settled on using "in
+   Situ".  Other similar uses, including [P4-INT-2.1] and
+   [I-D.kumar-ippm-ifa], still use variations of "in-band", "in band",
+   or "inband".
 
-      Initially, "In situ OAM" [RFC9197] was also referred to as "In-
-      band OAM" [I-D.brockners-inband-oam-data], but was renamed due to
-      the overloaded meaning of "In-band OAM".  Further, [RFC9232] also
-      intertwines the terms "in-band" with "in situ", though
-      [I-D.song-opsawg-ifit-framework] settled on using "in Situ".
-      Other similar uses, including [P4-INT-2.1] and
-      [I-D.kumar-ippm-ifa], still use variations of "in-band", "in
-      band", or "inband".
+3.4.  Using Multiple Criteria
 
-   Packet Forwarding Treatment OAM:  OAM in relation to the forwarding
-      treatment of user data packets, as for example QoS treatment.
+   Note that OAM can be classified in relation to multiple criteria,
+   e.g., relating to both topological congruence and packet treatment,
+   as well as other criteria, such as active, passive or hybrid
+   [RFC7799].  For example, [RFC9551] classifies OAM both in terms of
+   whether it is active or passive as well as in terms of whether it
+   receives the same treatment as the user traffic.
 
-      Equal-Forwarding-Treatment OAM:
-         The OAM packets receive the same forwarding (e.g., QoS)
-         treatment as user data packets.  This was sometimes referred to
-         as "in-band".
-
-      Different-Forwarding-Treatment OAM:
-         The OAM packets receive different forwarding (e.g., QoS)
-         treatment as user data packets.  This was sometimes referred to
-         as "out-of-band".
-
-      As an example, the behavior of "Equal-Forwarding-Treatment OAM" is
-
-
-
-
-
-
-
-
-
-
-
-
-
-Pignataro, et al.       Expires 10 December 2025                [Page 5]
-
-Internet-Draft             Characterizing OAM                  June 2025
-
-
-      described in [RFC9551] as "it traverses the same set of links and
-      interfaces receiving the same QoS and Packet Replication,
-      Elimination, and Ordering Functions (PREOF) treatment as the
-      monitored DetNet flow".  This is classified in [RFC9551] as "In-
-      band OAM".  Similarly, the property of "Different-Forwarding-
-      Treatment OAM" can be found in the following definition in
-      [RFC9551]: "Out-of-band OAM: an active OAM method whose path
-      through the DetNet domain may not be topologically identical to
-      the path of the monitored DetNet flow, its test packets may
-      receive different QoS and/or PREOF treatment, or both."
-      [I-D.ietf-raw-architecture] uses similar text.
-
-      Note that OAM can be classified in relation to multiple criteria,
-      e.g., relating to both topological congruence and packet
-      treatment, as well as other criteria, such as active, passive or
-      hybrid [RFC7799].  For example, [RFC9551] classifies OAM both in
-      terms of whether it is active or passive as well as in terms of
-      whether it receives the same treatment as the user traffic.
-
-2.2.  Historical Uses
-
-   There are many examples of "in-band OAM" and "out-of-band OAM" in
-   published RFCs.  For instance, the term "in-band" appears in both
-   [RFC5085] and [RFC9551].  While the context in each of these
-   documents is clear, the term carries different meanings in each case.
-
-   While interpreting existing documents, it is important to understand
-   the semantics of what "band" is a proxy for, and to be more explicit
-   if those documents are updated.  This document does not change the
-   meaning of any terms in any prior RFCs.
-
-3.  Security Considerations
+4.  Security Considerations
 
    Security is improved when terms are used with precision, and their
    definitions are unambiguous.
 
-4.  IANA Considerations
+5.  IANA Considerations
 
    This document has no IANA actions.
 
-5.  Acknowledgements
+6.  Acknowledgements
 
    The creation of this document was triggered when observing one of
    many on-mailing-list discussions of what these terms mean, and how to
@@ -330,15 +326,17 @@ Internet-Draft             Characterizing OAM                  June 2025
    alphabetically: Adrian Farrel, Alexander Vainshtein, Florian Kauer,
    Frank Brockners, Greg Mirsky, Italo Busi, Loa Andersson, Med
    Boucadair, Michael Richardson, Quan Xiong, Stewart Bryant, Tom Petch,
+   Eduard Vasilenko, and Xiao Min.
 
 
 
-Pignataro, et al.       Expires 10 December 2025                [Page 6]
+
+
+
+Pignataro, et al.       Expires 12 December 2025                [Page 6]
 
 Internet-Draft             Characterizing OAM                  June 2025
 
-
-   Eduard Vasilenko, and Xiao Min.
 
    The authors wish to thank, chronologically, Hesham Elbakoury, Michael
    Richardson, Stewart Bryant, Greg Mirsky, Med Boucadair, Loa
@@ -347,9 +345,9 @@ Internet-Draft             Characterizing OAM                  June 2025
    their thorough review and useful feedback comments that greatly
    improved this document.
 
-6.  References
+7.  References
 
-6.1.  Normative References
+7.1.  Normative References
 
    [RFC6291]  Andersson, L., van Helvoort, H., Bonica, R., Romascanu,
               D., and S. Mansfield, "Guidelines for the Use of the "OAM"
@@ -357,14 +355,7 @@ Internet-Draft             Characterizing OAM                  June 2025
               DOI 10.17487/RFC6291, June 2011,
               <https://www.rfc-editor.org/info/rfc6291>.
 
-6.2.  Informative References
-
-   [I-D.brockners-inband-oam-data]
-              Brockners, F., Bhandari, S., Pignataro, C., and H.
-              Gredler, "Data Formats for In-band OAM", Work in Progress,
-              Internet-Draft, draft-brockners-inband-oam-data-00, 8 July
-              2016, <https://datatracker.ietf.org/doc/html/draft-
-              brockners-inband-oam-data-00>.
+7.2.  Informative References
 
    [I-D.ietf-raw-architecture]
               Thubert, P., "Reliable and Available Wireless
@@ -381,19 +372,6 @@ Internet-Draft             Characterizing OAM                  June 2025
               <https://datatracker.ietf.org/doc/html/draft-kumar-ippm-
               ifa-08>.
 
-
-
-
-
-
-
-
-
-Pignataro, et al.       Expires 10 December 2025                [Page 7]
-
-Internet-Draft             Characterizing OAM                  June 2025
-
-
    [I-D.song-opsawg-ifit-framework]
               Song, H., Qin, F., Chen, H., Jin, J., and J. Shin,
               "Framework for In-situ Flow Information Telemetry", Work
@@ -406,6 +384,15 @@ Internet-Draft             Characterizing OAM                  June 2025
               "In-band Network Telemetry (INT) Dataplane Specification,
               Version 2.1", 11 November 2020,
               <https://p4.org/p4-spec/docs/INT_v2_1.pdf>.
+
+
+
+
+
+Pignataro, et al.       Expires 12 December 2025                [Page 7]
+
+Internet-Draft             Characterizing OAM                  June 2025
+
 
    [RFC4733]  Schulzrinne, H. and T. Taylor, "RTP Payload for DTMF
               Digits, Telephony Tones, and Telephony Signals", RFC 4733,
@@ -442,14 +429,6 @@ Internet-Draft             Characterizing OAM                  June 2025
               and Maintenance (IOAM)", RFC 9197, DOI 10.17487/RFC9197,
               May 2022, <https://www.rfc-editor.org/info/rfc9197>.
 
-
-
-
-Pignataro, et al.       Expires 10 December 2025                [Page 8]
-
-Internet-Draft             Characterizing OAM                  June 2025
-
-
    [RFC9232]  Song, H., Qin, F., Martinez-Julia, P., Ciavaglia, L., and
               A. Wang, "Network Telemetry Framework", RFC 9232,
               DOI 10.17487/RFC9232, May 2022,
@@ -459,6 +438,17 @@ Internet-Draft             Characterizing OAM                  June 2025
               and T. Zhou, "Alternate-Marking Method", RFC 9341,
               DOI 10.17487/RFC9341, December 2022,
               <https://www.rfc-editor.org/info/rfc9341>.
+
+
+
+
+
+
+
+Pignataro, et al.       Expires 12 December 2025                [Page 8]
+
+Internet-Draft             Characterizing OAM                  June 2025
+
 
    [RFC9551]  Mirsky, G., Theoleyre, F., Papadopoulos, G., Bernardos,
               CJ., Varga, B., and J. Farkas, "Framework of Operations,
@@ -501,4 +491,14 @@ Authors' Addresses
 
 
 
-Pignataro, et al.       Expires 10 December 2025                [Page 9]
+
+
+
+
+
+
+
+
+
+
+Pignataro, et al.       Expires 12 December 2025                [Page 9]

--- a/draft-ietf-opsawg-oam-characterization.xml
+++ b/draft-ietf-opsawg-oam-characterization.xml
@@ -131,37 +131,48 @@
           Historically, the terms "in-band" and "out-of-band" were used extensively in radio communications as well as in telephony signaling <xref target="RFC4733" />. In both these cases, there is an actual "Band" (i.e., a "Channel" or "Frequency") to be within or outside.
         </t>
         <t>
-          While those terms, useful in their simplicity, continued to be broadly used to mean "within something" and "outside something", a challenge is presented for IP communications and packet-switched networks (PSNs) which do not have a "band" per se, and, in fact, have multiple "somethings" that OAM can be carried within or outside. A frequently encountered case is the use of "in-band" to mean either in-packet or on-path.
+          While those terms, useful in their simplicity, continued to be broadly used to mean "within something" and "outside something", a challenge is presented for IP communications and packet-switched networks (PSNs) which do not have a "band" per se, and, in fact, have multiple "somethings" that OAM traffic can be carried within or outside. A frequently encountered case is the use of "in-band" to mean either in-packet or on-path.
         </t>
         <t>
           Within the IETF, the terms "in-band" and "out-of-band" cannot be reliably understood consistently and unambiguously. Context-specific definitions of these terms are inconsistent and therefore cannot be generalized. More importantly, the terms are not self-defining to any further extent and cannot be understood by someone exposed to them for the first time, since there is no "band" in IP.
         </t>
 
-      <section anchor="terms" title="Terminology and Guidance">
+            <t>
+              There are many examples of "in-band OAM" and "out-of-band OAM" in published RFCs. For instance, the term "in-band" appears in both <xref target="RFC5085" /> and <xref target="RFC9551" />. While the context in each of these documents is clear, the term carries different meanings in each case. These two examples, as well as other examples of uses of the term "in-band" in previous documents are described throughout <xref target="terms" />.
+            </t>
+            <t>
+			  While interpreting existing documents, it is important to understand the semantics of what "band" is a proxy for, and to be more explicit if those documents are updated. This document does not change the meaning of any terms in any prior RFCs.
+          </t>
 
+      </section>
+
+
+      <section anchor="terms" title="Terminology and Guidance">
 
         <t>
           This document recommends avoiding the terms "in-band" and "out-of-band" when referring to OAM. Instead, it encourages the use of more fine-grained and descriptive terminology. The document also presents alternative terms and definitions for use in future IETF documents referencing OAM, without precluding the use of other precise, descriptive terms that do not rely on the "-band" convention.
         </t>
+
         <t>
-          In this document, the term "path-congruent packets" describes packets that follow the exact same path (i.e., traverse the same nodes and links) within a network. Note that this definition does not describe how the packets are treated in queues within the nodes on the path. A further concept, "equal-forwarding-treatment" describes how path-congruent packets receive the same forwarding treatment (e.g., Quality of Service (QoS)) .
+          The terminology presented in this section classifies OAM according to three criteria: whether it follows the same path as data traffic; whether it receives the same treatment as data traffic; and whether it operates in an active, passive, or hybrid mode.
         </t>
-        <t>
 
 
-          <list style="hanging">
-
-
-<t hangText="Path OAM:"> OAM in relation to a path</t>
+      <section title="Path Followed OAM">
 <t>
           <list style="hanging">
 <t hangText="Path-Congruent OAM:"><br />The OAM information follows the exact same path as the observed data traffic. This was sometimes referred to as "in-band".</t>
 <t hangText="Non-Path-Congruent OAM:"><br />The OAM information does not follow the exact same path as the observed data traffic. This can also be called Path-Incongruent OAM, and was sometimes referred to as "out-of-band".</t>
           </list>
 </t>
+
+        <t>
+          In this document, the term "path-congruent packets" describes packets that follow the exact same path (i.e., traverse the same nodes and links) within a network. Note that this definition does not describe how the packets are treated in queues within the nodes on the path. A further concept, "equal-forwarding-treatment" describes how path-congruent packets receive the same forwarding treatment (e.g., Quality of Service (QoS)).
+        </t>
+
         <t>An example of "Path-Congruent OAM" is the Virtual 
 		Circuit Connectivity Verification (VCCV), described
-		is Section 6 of <xref target="RFC5085" /> as "The VCCV
+		is <xref target="RFC5085" /> as "The VCCV
         message travels in-band with the Session and follows the exact same
         path as the user data for the session". Thus,
 		the term "in-band" in <xref target="RFC5085" /> refers to using the same path as the user data.
@@ -169,67 +180,9 @@
         and the word "congruent" is mentioned as synonymous.		
 		</t>
 
+      </section>
 
-<t hangText="Active, Passive, Hybrid, and In-Packet OAM"></t>
-
-          <t>
-               <xref target="RFC7799" /> provides clear definitions for active and passive
-               performance assessment such that the construction of metrics and
-               methods can be described as either "Active" or "Passive".  Even
-               though <xref target="RFC7799" /> does not include the specific terms "Active",
-               "Passive", or "Hybrid" as modifiers of "OAM", the following terms
-               are used in many RFCs and are provided here for clarity.
-          
-            <list style="hanging">
-              <t hangText="Active OAM:"><br /> Depends on dedicated OAM packets.</t>
-              <t hangText="Passive OAM:"><br /> Depends solely on the observation of one
-      or more existing data packet streams and does not use dedicated OAM packets.</t>
-               <t hangText="Hybrid OAM:"><br /> Uses instrumentation or modification of the data 
-                 stream. Examples of protocols classified as "Hybrid OAM" 
-                 include <xref target="RFC9341" />, <xref target="RFC9197" />, and <xref target="RFC6374" />. Hybrid 
-                 OAM can be implemented by piggybacking OAM-related information onto data 
-                 packets, as described in <xref target="RFC9197" />, or by utilizing reserved 
-                 fields in the packet header or specific values of existing header fields, 
-                 as proposed in <xref target="RFC9341" />. Direct loss measurment <xref target="RFC6374" />
-				         is an example of "Hybrid OAM" in which user packets are not modified by the protocol. Instead,
-				         OAM packets are used to exchange information about user packet counters, allowing for
-				         packet loss computation.
-               </t>
-            </list>
-          </t>
-
-            <t>This document defines the term In-Packet OAM, which is a special case of Hybrid OAM:</t>
-<t>
-          <list style="hanging">
-<t hangText="In-Packet OAM:"><br />The OAM information is carried in the packets that also carry the data traffic. This was sometimes referred to as "in-band".</t>
-          </list>
-</t>
-
-<t>
-  The MPLS echo request/reply messages <xref target="RFC8029" /> are an example of "Active OAM", since they are described as "An MPLS echo request/reply is a (possibly MPLS-labeled) IPv4 or IPv6 UDP packet".
-</t>
-
-
-<t>In situ OAM <xref target="RFC9197" /> is an example of "In-Packet OAM", given that it: '...records OAM information
-  within the packet while the packet traverses a particular network
-  domain.  The term "in situ" refers to the fact that the OAM data is
-  added to the data packets rather than being sent within packets
-  specifically dedicated to OAM.' On the other hand, direct loss measurement <xref target="RFC6374" />
-  is an example of "Hybrid OAM" which is not classified as "In-Packet OAM".
-</t>
-<t>
-  Initially, "In situ OAM" <xref target="RFC9197" /> was also referred to as "In-band OAM" <xref target="I-D.brockners-inband-oam-data" />, but was renamed due to the overloaded meaning of "In-band OAM". Further, <xref target="RFC9232" /> also intertwines the terms "in-band" with "in situ", though <xref target="I-D.song-opsawg-ifit-framework" /> settled on using "in Situ". Other similar uses, including <xref target="P4-INT-2.1" /> and <xref target="I-D.kumar-ippm-ifa" />, still use variations of "in-band", "in band", or "inband".
-</t>
-
-<!--
-<t>
-  It is noteworthy that In-Packet OAM cannot be Non-Path-Congruent OAM.
-</t>
--->
-
-
-
-<t hangText="Packet Forwarding Treatment OAM:"> OAM in relation to the forwarding treatment of user data packets, as for example QoS treatment.</t>
+      <section title="Packet Forwarding Treatment OAM">
 <t>
           <list style="hanging">
 <t hangText="Equal-Forwarding-Treatment OAM:"><br />The OAM packets receive the same forwarding (e.g., QoS) treatment as user data packets. This was sometimes referred to as "in-band".</t>
@@ -246,30 +199,79 @@ an active OAM method whose path through the DetNet domain may not be topological
 
 </t>
 
+      </section>
+
+
+      <section title="Active, Passive, Hybrid, and In-Packet OAM">
+
+          <t>
+               <xref target="RFC7799" /> provides clear definitions for active and passive
+               performance assessment such that the construction of metrics and
+               methods can be described as either "Active" or "Passive".  Even
+               though <xref target="RFC7799" /> does not include the specific terms "Active",
+               "Passive", or "Hybrid" as modifiers of "OAM", the following terms
+               are used in many RFCs and are provided here for clarity.
+          
+            <list style="hanging">
+              <t hangText="Active OAM:"><br /> Depends on dedicated OAM packets.</t>
+              <t hangText="Passive OAM:"><br /> Depends solely on the observation of one
+      or more existing data packet streams and does not use dedicated OAM packets.</t>
+               <t hangText="Hybrid OAM:"><br /> Uses augmentation or modification of the packet 
+                 stream. Examples of protocols classified as "Hybrid OAM" 
+                 include <xref target="RFC9341" />, <xref target="RFC9197" />, and <xref target="RFC6374" />. Hybrid 
+                 OAM can be implemented by piggybacking OAM-related information onto data 
+                 packets, as described in <xref target="RFC9197" />, or by utilizing reserved 
+                 fields in the packet header or specific values of existing header fields, 
+                 as proposed in <xref target="RFC9341" />. Direct loss measurment <xref target="RFC6374" />
+		 is an example of "Hybrid OAM" in which user packets are not modified by the protocol. Instead,
+		 OAM packets are used to exchange information about user packet counters, allowing for
+		 packet loss computation.
+               </t>
+            </list>
+          </t>
+
+          <t>This document defines the term In-Packet OAM as a more specific and narrowly scoped instance within the broader category of Hybrid OAM.</t>
+<t>
+          <list style="hanging">
+<t hangText="In-Packet OAM:"><br />The OAM information is carried in the packets that also carry the data traffic. This was sometimes referred to as "in-band".</t>
+          </list>
+</t>
+
+<t>
+  The MPLS echo request/reply messages <xref target="RFC8029" /> are an example of "Active OAM", since they are described as "An MPLS echo request/reply is a (possibly MPLS-labeled) IPv4 or IPv6 UDP packet".
+</t>
+
+
+<t>In situ OAM <xref target="RFC9197" /> is an example of "Hybrid OAM" that is also "In-Packet OAM", given that it: '...records OAM information
+  within the packet while the packet traverses a particular network
+  domain.  The term "in situ" refers to the fact that the OAM data is
+  added to the data packets rather than being sent within packets
+  specifically dedicated to OAM.' 
+</t>
+
+<t>An example of "Hybrid OAM" which is not classified as "In-Packet OAM" is Direct loss measurement <xref target="RFC6374" />.
+</t>
+<t>
+  Initially, "In situ OAM" <xref target="RFC9197" /> was also referred to as "In-band OAM", but was renamed due to the overloaded meaning of "In-band OAM". Further, <xref target="RFC9232" /> also intertwines the terms "in-band" with "in situ", though <xref target="I-D.song-opsawg-ifit-framework" /> settled on using "in Situ". Other similar uses, including <xref target="P4-INT-2.1" /> and <xref target="I-D.kumar-ippm-ifa" />, still use variations of "in-band", "in band", or "inband".
+</t>
+
+<!--
+<t>
+  It is noteworthy that In-Packet OAM cannot be Non-Path-Congruent OAM.
+</t>
+-->
+
+      </section>
+
+
+      <section title="Using Multiple Criteria">
 
 <t>Note that OAM can be classified in relation to multiple criteria, e.g., relating to both topological congruence and packet treatment, as well as other criteria, such as active, passive or hybrid <xref target="RFC7799" />. 
 For example, <xref target="RFC9551" /> classifies OAM both in terms of whether it is active or passive as well as in terms of whether it receives the same treatment as the user traffic. 
 </t>
-
-
-          </list>
-        </t>
-
-    </section>
-
-    <section anchor="Historical" title="Historical Uses">
-            <t>
-              There are many examples of "in-band OAM" and "out-of-band OAM" in published RFCs. For instance, the term "in-band" appears in both <xref target="RFC5085" /> and <xref target="RFC9551" />. While the context in each of these documents is clear, the term carries different meanings in each case.
-            </t>
-            <t>
-			  While interpreting existing documents, it is important to understand the semantics of what "band" is a proxy for, and to be more explicit if those documents are updated. This document does not change the meaning of any terms in any prior RFCs.
-          </t>
-
-    </section>
-
-
-
       </section>
+
+    </section>
 
 
 
@@ -320,21 +322,6 @@ For example, <xref target="RFC9551" /> classifies OAM both in terms of whether i
       &I-D.song-opsawg-ifit-framework;
       &RFC.9551;
       &I-D.kumar-ippm-ifa;
-
-<reference anchor="I-D.brockners-inband-oam-data" target="https://datatracker.ietf.org/doc/html/draft-brockners-inband-oam-data-00">
-<front>
-<title>Data Formats for In-band OAM</title>
-<author initials="F." surname="Brockners" fullname="Frank Brockners"> </author>
-<author initials="S." surname="Bhandari" fullname="Shwetha Bhandari"> </author>
-<author initials="C." surname="Pignataro" fullname="Carlos Pignataro"> </author>
-<author initials="H." surname="Gredler" fullname="Hannes Gredler"> </author>
-<date month="July" day="8" year="2016"/>
-<abstract>
-<t> In-band operation, administration and maintenance (OAM) records operational and telemetry information in the packet while the packet traverses a path between two points in the network. This document discusses the data types and data formats for in-band OAM data records. In-band OAM data records can be embedded into a variety of transports such as NSH, Segment Routing, VXLAN-GPE, native IPv6 (via extension header), or IPv4. In-band OAM is to complement current out-of-band OAM mechanisms based on ICMP or other types of probe packets. </t>
-</abstract>
-</front>
-<seriesInfo name="Internet-Draft" value="draft-brockners-inband-oam-data-00"/>
-</reference>
 
       <reference anchor="P4-INT-2.1" target="https://p4.org/p4-spec/docs/INT_v2_1.pdf">
         <front>


### PR DESCRIPTION
The changes are mostly in response to the comments from Tim Chown: https://mailarchive.ietf.org/arch/msg/opsawg/Lrc5f0wcSuRdN2BSf8s2A8wB_0w/

The main changes are:
- "Terminology and Guidance" was moved into a separate section (section 3), with a subsection for each criterion.
- "Historical Uses" was merged into "In-Band and Out-of-Band OAM" (section 2).
- The term "Hybrid OAM" was slightly reworded based on the feedback.
- Slightly clarified the example illustrating the difference between hybrid and in-packet OAM.
- Some text was moved without many changes. The diff may look like there are a lot of changes, but most are due to changing the order.
- The reference to draft-brockners was removed.