### PR TITLE
Version 10

### DIFF
--- a/draft-ietf-opsawg-oam-characterization.html
+++ b/draft-ietf-opsawg-oam-characterization.html
@@ -25,16 +25,16 @@
       use of the term "OAM". It does not modify any other part of RFC
       6291. 
     ' name="description">
-<meta content="xml2rfc 3.29.0" name="generator">
-<meta content="draft-ietf-opsawg-oam-characterization-09" name="ietf.draft">
+<meta content="xml2rfc 3.30.0" name="generator">
+<meta content="draft-ietf-opsawg-oam-characterization-10" name="ietf.draft">
 <!-- Generator version information:
-  xml2rfc 3.29.0
+  xml2rfc 3.30.0
     Python 3.12.3
     ConfigArgParse 1.7.1
     google-i18n-address 3.1.1
     intervaltree 3.1.0
     Jinja2 3.1.6
-    lxml 5.4.0
+    lxml 6.0.0
     platformdirs 4.3.8
     pycountry 24.6.1
     PyYAML 6.0.2
@@ -43,7 +43,7 @@
     wcwidth 0.2.13
     weasyprint 65.0
 -->
-<link href="draft-ietf-opsawg-oam-characterization.xml" rel="alternate" type="application/rfc+xml">
+<link href="draft-ietf-opsawg-oam-characterization-10.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 
@@ -1203,6 +1203,7 @@ dl > dd > dl {
 /* This should match the element list in writer.text.TextWriter.render_dl() */
 dd > div.artwork:first-child,
 dd > aside:first-child,
+dd > blockquote:first-child,
 dd > figure:first-child,
 dd > ol:first-child,
 dd > div.sourcecode:first-child,
@@ -1236,7 +1237,7 @@ li > p:last-of-type:only-child {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Pignataro, et al.</td>
-<td class="center">Expires 3 January 2026</td>
+<td class="center">Expires 31 January 2026</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -1246,18 +1247,18 @@ li > p:last-of-type:only-child {
 <dt class="label-workgroup">Workgroup:</dt>
 <dd class="workgroup">OPS Area Working Group</dd>
 <dt class="label-internet-draft">Internet-Draft:</dt>
-<dd class="internet-draft">draft-ietf-opsawg-oam-characterization-09</dd>
+<dd class="internet-draft">draft-ietf-opsawg-oam-characterization-10</dd>
 <dt class="label-updates">Updates:</dt>
 <dd class="updates">
 <a href="https://www.rfc-editor.org/rfc/rfc6291" class="eref">6291</a> (if approved)</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2025-07-02" class="published">2 July 2025</time>
+<time datetime="2025-07-30" class="published">30 July 2025</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Best Current Practice</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2026-01-03">3 January 2026</time></dd>
+<dd class="expires"><time datetime="2026-01-31">31 January 2026</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -1313,7 +1314,7 @@ li > p:last-of-type:only-child {
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 3 January 2026.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 31 January 2026.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -1352,7 +1353,7 @@ li > p:last-of-type:only-child {
             <p id="section-toc.1-1.3.1"><a href="#section-3" class="auto internal xref">3</a>.  <a href="#name-terminology-and-guidance" class="internal xref">Terminology and Guidance</a></p>
 <ul class="compact toc ulBare ulEmpty">
 <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3.2.1">
-                <p id="section-toc.1-1.3.2.1.1" class="keepWithNext"><a href="#section-3.1" class="auto internal xref">3.1</a>.  <a href="#name-active-passive-hybrid-and-i" class="internal xref">Active, Passive, Hybrid, and In-Packet OAM</a></p>
+                <p id="section-toc.1-1.3.2.1.1" class="keepWithNext"><a href="#section-3.1" class="auto internal xref">3.1</a>.  <a href="#name-active-passive-hybrid-and-i" class="internal xref">Active, Passive, Hybrid, and In-Data-Packet OAM</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3.2.2">
                 <p id="section-toc.1-1.3.2.2.1"><a href="#section-3.2" class="auto internal xref">3.2</a>.  <a href="#name-path-followed-oam" class="internal xref">Path Followed OAM</a></p>
@@ -1386,7 +1387,10 @@ li > p:last-of-type:only-child {
             </ul>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8">
-            <p id="section-toc.1-1.8.1"><a href="#appendix-A" class="auto internal xref"></a><a href="#name-authors-addresses" class="internal xref">Authors' Addresses</a></p>
+            <p id="section-toc.1-1.8.1"><a href="#appendix-A" class="auto internal xref">Appendix A</a>.  <a href="#name-examples-of-the-use-of-the-" class="internal xref">Examples of the Use of the Term In-Band</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9">
+            <p id="section-toc.1-1.9.1"><a href="#appendix-B" class="auto internal xref"></a><a href="#name-authors-addresses" class="internal xref">Authors' Addresses</a></p>
 </li>
         </ul>
 </nav>
@@ -1426,7 +1430,7 @@ li > p:last-of-type:only-child {
       networks (PSNs) which do not have a "band" per se, and, in fact, have
       multiple "somethings" that OAM traffic can be carried within or outside.
       A frequently encountered case is the use of "in-band" to mean either
-      In-Packet or on-path.<a href="#section-2-2" class="pilcrow">¶</a></p>
+      In-Data-Packet or on-path.<a href="#section-2-2" class="pilcrow">¶</a></p>
 <p id="section-2-3">Within the IETF, the terms "in-band" and "out-of-band" cannot be
       reliably understood consistently and unambiguously. Context-specific
       definitions of these terms are inconsistent and therefore cannot be
@@ -1462,7 +1466,7 @@ li > p:last-of-type:only-child {
       receives the same treatment as data traffic.<a href="#section-3-2" class="pilcrow">¶</a></p>
 <section id="section-3.1">
         <h3 id="name-active-passive-hybrid-and-i">
-<a href="#section-3.1" class="section-number selfRef">3.1. </a><a href="#name-active-passive-hybrid-and-i" class="section-name selfRef">Active, Passive, Hybrid, and In-Packet OAM</a>
+<a href="#section-3.1" class="section-number selfRef">3.1. </a><a href="#name-active-passive-hybrid-and-i" class="section-name selfRef">Active, Passive, Hybrid, and In-Data-Packet OAM</a>
         </h3>
 <p id="section-3.1-1"><span>[<a href="#RFC7799" class="cite xref">RFC7799</a>]</span> provides clear definitions for active and
         passive performance assessment, enabling the construction of metrics
@@ -1470,7 +1474,9 @@ li > p:last-of-type:only-child {
         though <span>[<a href="#RFC7799" class="cite xref">RFC7799</a>]</span> does not explicitly use these terms as
         modifiers of "OAM", they are widely used in practice and are included
         here for clarity. The terms "Active", "Passive" and "Hybrid", as
-        described below, are consistent with <span>[<a href="#RFC7799" class="cite xref">RFC7799</a>]</span>.<a href="#section-3.1-1" class="pilcrow">¶</a></p>
+        described below, are consistent with <span>[<a href="#RFC7799" class="cite xref">RFC7799</a>]</span>. This
+        document does not update or change the terms of 
+        <span>[<a href="#RFC7799" class="cite xref">RFC7799</a>]</span>.<a href="#section-3.1-1" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="dlParallel" id="section-3.1-2">
           <dt id="section-3.1-2.1">Active OAM:</dt>
           <dd style="margin-left: 1.5em" id="section-3.1-2.2">
@@ -1488,26 +1494,17 @@ li > p:last-of-type:only-child {
 <dt id="section-3.1-2.5">Hybrid OAM:</dt>
           <dd style="margin-left: 1.5em" id="section-3.1-2.6">
             <br> Uses augmentation or modification
-            of the packet stream. Examples of protocols classified as "Hybrid
-            OAM" include Alternate Marking <span>[<a href="#RFC9341" class="cite xref">RFC9341</a>]</span>, In situ 
-            OAM (IOAM) <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span>, and MPLS Loss Measurement 
-            <span>[<a href="#RFC6374" class="cite xref">RFC6374</a>]</span>. Hybrid OAM can be implemented by
-            piggybacking OAM-related information onto data packets, as
-            described in <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span>, or by utilizing reserved
-            fields in the packet header or specific values of existing header
-            fields, as proposed in <span>[<a href="#RFC9341" class="cite xref">RFC9341</a>]</span>. Direct loss
-            measurment <span>[<a href="#RFC6374" class="cite xref">RFC6374</a>]</span> is an example of "Hybrid OAM"
-            in which user packets are not modified by the protocol. Instead,
-            OAM packets are used to exchange information about user packet
-            counters, allowing for packet loss computation.<a href="#section-3.1-2.6" class="pilcrow">¶</a>
+            of the packet stream. <span>[<a href="#RFC7799" class="cite xref">RFC7799</a>]</span> makes a distinction
+            between Hybrid Type I, referring to a single stream of interest,
+            and Hybrid Type II, referring to two or more streams of interest.<a href="#section-3.1-2.6" class="pilcrow">¶</a>
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-3.1-3">This document defines the term In-Packet OAM as a more specific and
+<p id="section-3.1-3">This document defines the term In-Data-Packet OAM as a more specific and
         narrowly scoped instance within the broader category of Hybrid
         OAM.<a href="#section-3.1-3" class="pilcrow">¶</a></p>
 <span class="break"></span><dl class="dlParallel" id="section-3.1-4">
-          <dt id="section-3.1-4.1">In-Packet OAM:</dt>
+          <dt id="section-3.1-4.1">In-Data-Packet OAM:</dt>
           <dd style="margin-left: 1.5em" id="section-3.1-4.2">
             <br>The OAM information is carried
             in the packets that also carry the data traffic. This is a 
@@ -1516,27 +1513,48 @@ li > p:last-of-type:only-child {
 </dd>
         <dd class="break"></dd>
 </dl>
-<p id="section-3.1-5">The MPLS echo request/reply messages <span>[<a href="#RFC8029" class="cite xref">RFC8029</a>]</span> are
-        an example of "Active OAM", since they are described as "An MPLS echo
-        request/reply is a (possibly MPLS-labeled) IPv4 or IPv6 UDP
-        packet".<a href="#section-3.1-5" class="pilcrow">¶</a></p>
-<p id="section-3.1-6">IOAM <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span> is an example of "Hybrid OAM"
-        that is also "In-Packet OAM", given that it: '...records OAM
-        information within the packet while the packet traverses a particular
-        network domain. The term "in situ" refers to the fact that the OAM
-        data is added to the data packets rather than being sent within
-        packets specifically dedicated to OAM.' Another example of In-Packet
-        OAM is Alternate Marking <span>[<a href="#RFC9341" class="cite xref">RFC9341</a>]</span>, in which a small 
-        number of bits in the packet header is used for marking a subset of 
-        packets in a flow.<a href="#section-3.1-6" class="pilcrow">¶</a></p>
-<p id="section-3.1-7">An example of "Hybrid OAM" which is not classified as "In-Packet
-        OAM" is Direct loss measurement <span>[<a href="#RFC6374" class="cite xref">RFC6374</a>]</span>.<a href="#section-3.1-7" class="pilcrow">¶</a></p>
-<p id="section-3.1-8">Initially, "In situ OAM" <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span> was also referred
-        to as "In-band OAM", but was renamed due to the overloaded meaning of
-        "In-band OAM". Further, <span>[<a href="#RFC9232" class="cite xref">RFC9232</a>]</span> also intertwines the
-        terms "in-band" with "in situ", though <span>[<a href="#I-D.song-opsawg-ifit-framework" class="cite xref">I-D.song-opsawg-ifit-framework</a>]</span> settled on using "in Situ".
-        Other similar uses, including <span>[<a href="#P4-INT-2.1" class="cite xref">P4-INT-2.1</a>]</span> and <span>[<a href="#I-D.kumar-ippm-ifa" class="cite xref">I-D.kumar-ippm-ifa</a>]</span>, still use variations of "in-band", "in
-        band", or "inband".<a href="#section-3.1-8" class="pilcrow">¶</a></p>
+<p id="section-3.1-5">The following examples illustrate the terms Active, Passive, 
+        Hybrid, and In-Data-Packet OAM:<a href="#section-3.1-5" class="pilcrow">¶</a></p>
+<ul class="normal">
+<li class="normal" id="section-3.1-6.1">
+            <p id="section-3.1-6.1.1">The MPLS echo request/reply messages <span>[<a href="#RFC8029" class="cite xref">RFC8029</a>]</span> are
+            an example of "Active OAM", since they are described as "An MPLS echo
+            request/reply is a (possibly MPLS-labeled) IPv4 or IPv6 UDP
+            packet".<a href="#section-3.1-6.1.1" class="pilcrow">¶</a></p>
+</li>
+          <li class="normal" id="section-3.1-6.2">
+            <p id="section-3.1-6.2.1">Monitoring a packet stream by maintaining counters for the 
+            packets within the stream is an example of "Passive OAM".<a href="#section-3.1-6.2.1" class="pilcrow">¶</a></p>
+</li>
+          <li class="normal" id="section-3.1-6.3">
+            <p id="section-3.1-6.3.1">IOAM <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span> is an example of "Hybrid OAM"
+           that is also "In-Data-Packet OAM", given that it: '...records OAM
+           information within the packet while the packet traverses a particular
+           network domain. The term "in situ" refers to the fact that the OAM
+           data is added to the data packets rather than being sent within
+           packets specifically dedicated to OAM.'<a href="#section-3.1-6.3.1" class="pilcrow">¶</a></p>
+</li>
+          <li class="normal" id="section-3.1-6.4">
+            <p id="section-3.1-6.4.1">Another example of "Hybrid OAM" that is also "In-Data-Packet 
+           OAM" is Alternate Marking <span>[<a href="#RFC9341" class="cite xref">RFC9341</a>]</span>, in which a small 
+           number of bits in the packet header is used for marking a subset of 
+           packets in a flow.<a href="#section-3.1-6.4.1" class="pilcrow">¶</a></p>
+</li>
+          <li class="normal" id="section-3.1-6.5">
+            <p id="section-3.1-6.5.1">An example of "Hybrid OAM" which is not classified as "In-Data-Packet
+           OAM" is Direct loss measurement <span>[<a href="#RFC6374" class="cite xref">RFC6374</a>]</span>,            
+           in which user packets are not modified by the protocol. Instead,
+           OAM packets are used to exchange information about user packet
+           counters, allowing for packet loss computation.<a href="#section-3.1-6.5.1" class="pilcrow">¶</a></p>
+</li>
+          <li class="normal" id="section-3.1-6.6">
+            <p id="section-3.1-6.6.1">Another example of "Hybrid OAM" which is not "In-Data-Packet OAM"
+           is the case where a packet stream is (actively) generated while 
+           an existing stream of interest is (passively) observed. This
+           example was introduced in <span>[<a href="#RFC7799" class="cite xref">RFC7799</a>]</span> as a Hybrid 
+           method.<a href="#section-3.1-6.6.1" class="pilcrow">¶</a></p>
+</li>
+        </ul>
 </section>
 <section id="section-3.2">
         <h3 id="name-path-followed-oam">
@@ -1569,10 +1587,8 @@ li > p:last-of-type:only-child {
 <p id="section-3.2-3">An example of "Path-Congruent OAM" is the Virtual Circuit
         Connectivity Verification (VCCV), described is <span>[<a href="#RFC5085" class="cite xref">RFC5085</a>]</span> as "The VCCV message travels in-band with the
         Session and follows the exact same path as the user data for the
-        session". Thus, the term "in-band" in <span>[<a href="#RFC5085" class="cite xref">RFC5085</a>]</span> refers
-        to using the same path as the user data. This term is also used in
-        Section 2 of <span>[<a href="#RFC6669" class="cite xref">RFC6669</a>]</span> with the same meaning, and the
-        word "congruent" is mentioned as synonymous.<a href="#section-3.2-3" class="pilcrow">¶</a></p>
+        session". The term "congruent" also appears in 
+        <span>[<a href="#RFC6669" class="cite xref">RFC6669</a>]</span> in the context of path sharing.<a href="#section-3.2-3" class="pilcrow">¶</a></p>
 </section>
 <section id="section-3.3">
         <h3 id="name-packet-forwarding-treatment">
@@ -1614,14 +1630,7 @@ li > p:last-of-type:only-child {
         <span>[<a href="#RFC9551" class="cite xref">RFC9551</a>]</span> in the context of DetNet OAM: "it traverses 
         the same set of links and interfaces receiving the same QoS and 
         Packet Replication, Elimination, and Ordering Functions (PREOF) 
-        treatment as the monitored DetNet flow". This is classified in 
-        <span>[<a href="#RFC9551" class="cite xref">RFC9551</a>]</span> as "In-band OAM". Similarly, the property of 
-        "Different-Forwarding-Treatment OAM" can be found in the following 
-        definition in <span>[<a href="#RFC9551" class="cite xref">RFC9551</a>]</span>: "Out-of-band OAM: an active 
-        OAM method whose path through the DetNet domain may not be 
-        topologically identical to the path of the monitored DetNet flow, its 
-        test packets may receive different QoS and/or PREOF treatment, or 
-        both." <span>[<a href="#I-D.ietf-raw-architecture" class="cite xref">I-D.ietf-raw-architecture</a>]</span> uses similar text.<a href="#section-3.3-3" class="pilcrow">¶</a></p>
+        treatment as the monitored DetNet flow".<a href="#section-3.3-3" class="pilcrow">¶</a></p>
 </section>
 <section id="section-3.4">
         <h3 id="name-using-multiple-criteria">
@@ -1635,7 +1644,7 @@ li > p:last-of-type:only-child {
         is recommended to explicitly consider which of these criteria are
         applicable and to describe the protocol accordingly. As a first step,
         all OAM mechanisms can be classified according to the first criterion,
-        as Active, Passive, or Hybrid/In-Packet. Further classification
+        as Active, Passive, or Hybrid/In-Data-Packet. Further classification
         according to the other two criteria should be considered on a 
         case-by-case basis.<a href="#section-3.4-2" class="pilcrow">¶</a></p>
 <p id="section-3.4-3">In some cases, certain criteria are not relevant, or not all 
@@ -1665,7 +1674,7 @@ li > p:last-of-type:only-child {
 </li>
           <li class="normal" id="section-3.4-6.2">
             <p id="section-3.4-6.2.1">When IOAM <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span> is incorporated in data
-            packets it can be classified as In-Packet, Path-Congruent and
+            packets it can be classified as In-Data-Packet, Path-Congruent and
             Equal-Forwarding-Treatment.<a href="#section-3.4-6.2.1" class="pilcrow">¶</a></p>
 </li>
           <li class="normal" id="section-3.4-6.3">
@@ -1685,8 +1694,14 @@ li > p:last-of-type:only-child {
             Different-Forwarding-Treatment OAM.<a href="#section-3.4-6.4.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
-<p id="section-3.4-7">This multi-dimensional classification enables a more precise and
-        consistent understanding of OAM mechanisms.<a href="#section-3.4-7" class="pilcrow">¶</a></p>
+<p id="section-3.4-7">In measurement protocols, accurate results depend on path 
+        congruence and equal forwarding treatment. In contrast, these 
+        properties are not always required in other OAM protocols. For 
+        example, Bidirectional Forwarding Detection (BFD) control packets 
+        are often sent with the highest priority, which means they do 
+        not adhere to the equal forwarding treatment property.<a href="#section-3.4-7" class="pilcrow">¶</a></p>
+<p id="section-3.4-8">This multi-dimensional classification enables a more precise and
+        consistent understanding of OAM mechanisms.<a href="#section-3.4-8" class="pilcrow">¶</a></p>
 </section>
 </section>
 </div>
@@ -1743,7 +1758,7 @@ li > p:last-of-type:only-child {
 <dl class="references">
 <dt id="I-D.ietf-raw-architecture">[I-D.ietf-raw-architecture]</dt>
         <dd>
-<span class="refAuthor">Thubert, P.</span>, <span class="refTitle">"Reliable and Available Wireless Architecture"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-ietf-raw-architecture-25</span>, <time datetime="2025-06-10" class="refDate">10 June 2025</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-ietf-raw-architecture-25">https://datatracker.ietf.org/doc/html/draft-ietf-raw-architecture-25</a>&gt;</span>. </dd>
+<span class="refAuthor">Thubert, P.</span>, <span class="refTitle">"Reliable and Available Wireless Architecture"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-ietf-raw-architecture-30</span>, <time datetime="2025-07-25" class="refDate">25 July 2025</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-ietf-raw-architecture-30">https://datatracker.ietf.org/doc/html/draft-ietf-raw-architecture-30</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 <dt id="I-D.kumar-ippm-ifa">[I-D.kumar-ippm-ifa]</dt>
         <dd>
@@ -1804,8 +1819,36 @@ li > p:last-of-type:only-child {
 </dl>
 </section>
 </section>
-<div id="authors-addresses">
+<div id="appendix">
 <section id="appendix-A">
+      <h2 id="name-examples-of-the-use-of-the-">
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-examples-of-the-use-of-the-" class="section-name selfRef">Examples of the Use of the Term In-Band</a>
+      </h2>
+<p id="appendix-A-1">While several instances of the term "in-band" were discussed 
+      throughout the document, this appendix provides additional examples. 
+      These are intended to highlight the varying interpretations of the term 
+      across different contexts.<a href="#appendix-A-1" class="pilcrow">¶</a></p>
+<p id="appendix-A-2">Initially, "In situ OAM" <span>[<a href="#RFC9197" class="cite xref">RFC9197</a>]</span> was also referred
+      to as "In-band OAM", but was renamed due to the overloaded meaning of
+      "In-band OAM". Further, <span>[<a href="#RFC9232" class="cite xref">RFC9232</a>]</span> also intertwines the
+      terms "in-band" with "in situ", though <span>[<a href="#I-D.song-opsawg-ifit-framework" class="cite xref">I-D.song-opsawg-ifit-framework</a>]</span> settled on using "in Situ".
+      Other similar uses, including <span>[<a href="#P4-INT-2.1" class="cite xref">P4-INT-2.1</a>]</span> and <span>[<a href="#I-D.kumar-ippm-ifa" class="cite xref">I-D.kumar-ippm-ifa</a>]</span>, still use variations of "in-band", "in
+      band", or "inband".<a href="#appendix-A-2" class="pilcrow">¶</a></p>
+<p id="appendix-A-3">The term "in-band" in <span>[<a href="#RFC5085" class="cite xref">RFC5085</a>]</span> refers
+      to using the same path as the user data. This term is also used in
+      Section 2 of <span>[<a href="#RFC6669" class="cite xref">RFC6669</a>]</span> with the same meaning.<a href="#appendix-A-3" class="pilcrow">¶</a></p>
+<p id="appendix-A-4">The property of "Equal-Forwarding-Treatment" is referred to in 
+      <span>[<a href="#RFC9551" class="cite xref">RFC9551</a>]</span> as "In-band OAM". Similarly, the property of 
+      "Different-Forwarding-Treatment OAM" can be found in the following 
+      definition in <span>[<a href="#RFC9551" class="cite xref">RFC9551</a>]</span>: "Out-of-band OAM: an active 
+      OAM method whose path through the DetNet domain may not be 
+      topologically identical to the path of the monitored DetNet flow, its 
+      test packets may receive different QoS and/or PREOF treatment, or 
+      both." <span>[<a href="#I-D.ietf-raw-architecture" class="cite xref">I-D.ietf-raw-architecture</a>]</span> uses similar text.<a href="#appendix-A-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="authors-addresses">
+<section id="appendix-B">
       <h2 id="name-authors-addresses">
 <a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
       </h2>

--- a/draft-ietf-opsawg-oam-characterization.txt
+++ b/draft-ietf-opsawg-oam-characterization.txt
@@ -6,13 +6,13 @@ OPS Area Working Group                                      C. Pignataro
 Internet-Draft                                      Blue Fern Consulting
 Updates: 6291 (if approved)                                    A. Farrel
 Intended status: Best Current Practice                Old Dog Consulting
-Expires: 3 January 2026                                       T. Mizrahi
+Expires: 31 January 2026                                      T. Mizrahi
                                                                   Huawei
-                                                             2 July 2025
+                                                            30 July 2025
 
 
                   Guidelines for Characterizing "OAM"
-               draft-ietf-opsawg-oam-characterization-09
+               draft-ietf-opsawg-oam-characterization-10
 
 Abstract
 
@@ -49,11 +49,11 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 3 January 2026.
+   This Internet-Draft will expire on 31 January 2026.
 
 
 
-Pignataro, et al.        Expires 3 January 2026                 [Page 1]
+Pignataro, et al.        Expires 31 January 2026                [Page 1]
 
 Internet-Draft             Characterizing OAM                  July 2025
 
@@ -77,7 +77,7 @@ Table of Contents
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
    2.  In-Band and Out-of-Band OAM . . . . . . . . . . . . . . . . .   3
    3.  Terminology and Guidance  . . . . . . . . . . . . . . . . . .   3
-     3.1.  Active, Passive, Hybrid, and In-Packet OAM  . . . . . . .   4
+     3.1.  Active, Passive, Hybrid, and In-Data-Packet OAM . . . . .   4
      3.2.  Path Followed OAM . . . . . . . . . . . . . . . . . . . .   5
      3.3.  Packet Forwarding Treatment OAM . . . . . . . . . . . . .   6
      3.4.  Using Multiple Criteria . . . . . . . . . . . . . . . . .   6
@@ -87,7 +87,8 @@ Table of Contents
    7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   8
      7.1.  Normative References  . . . . . . . . . . . . . . . . . .   8
      7.2.  Informative References  . . . . . . . . . . . . . . . . .   8
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  10
+   Appendix A.  Examples of the Use of the Term In-Band  . . . . . .  10
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  11
 
 1.  Introduction
 
@@ -108,8 +109,7 @@ Table of Contents
 
 
 
-
-Pignataro, et al.        Expires 3 January 2026                 [Page 2]
+Pignataro, et al.        Expires 31 January 2026                [Page 2]
 
 Internet-Draft             Characterizing OAM                  July 2025
 
@@ -131,7 +131,7 @@ Internet-Draft             Characterizing OAM                  July 2025
    networks (PSNs) which do not have a "band" per se, and, in fact, have
    multiple "somethings" that OAM traffic can be carried within or
    outside.  A frequently encountered case is the use of "in-band" to
-   mean either In-Packet or on-path.
+   mean either In-Data-Packet or on-path.
 
    Within the IETF, the terms "in-band" and "out-of-band" cannot be
    reliably understood consistently and unambiguously.  Context-specific
@@ -165,7 +165,7 @@ Internet-Draft             Characterizing OAM                  July 2025
 
 
 
-Pignataro, et al.        Expires 3 January 2026                 [Page 3]
+Pignataro, et al.        Expires 31 January 2026                [Page 3]
 
 Internet-Draft             Characterizing OAM                  July 2025
 
@@ -175,7 +175,7 @@ Internet-Draft             Characterizing OAM                  July 2025
    mode; whether it follows the same path as data traffic; and whether
    it receives the same treatment as data traffic.
 
-3.1.  Active, Passive, Hybrid, and In-Packet OAM
+3.1.  Active, Passive, Hybrid, and In-Data-Packet OAM
 
    [RFC7799] provides clear definitions for active and passive
    performance assessment, enabling the construction of metrics and
@@ -183,7 +183,8 @@ Internet-Draft             Characterizing OAM                  July 2025
    [RFC7799] does not explicitly use these terms as modifiers of "OAM",
    they are widely used in practice and are included here for clarity.
    The terms "Active", "Passive" and "Hybrid", as described below, are
-   consistent with [RFC7799].
+   consistent with [RFC7799].  This document does not update or change
+   the terms of [RFC7799].
 
    Active OAM:
       Depends on dedicated OAM packets.
@@ -193,58 +194,60 @@ Internet-Draft             Characterizing OAM                  July 2025
       packet streams and does not use dedicated OAM packets.
 
    Hybrid OAM:
-      Uses augmentation or modification of the packet stream.  Examples
-      of protocols classified as "Hybrid OAM" include Alternate Marking
-      [RFC9341], In situ OAM (IOAM) [RFC9197], and MPLS Loss Measurement
-      [RFC6374].  Hybrid OAM can be implemented by piggybacking OAM-
-      related information onto data packets, as described in [RFC9197],
-      or by utilizing reserved fields in the packet header or specific
-      values of existing header fields, as proposed in [RFC9341].
-      Direct loss measurment [RFC6374] is an example of "Hybrid OAM" in
-      which user packets are not modified by the protocol.  Instead, OAM
-      packets are used to exchange information about user packet
-      counters, allowing for packet loss computation.
+      Uses augmentation or modification of the packet stream.  [RFC7799]
+      makes a distinction between Hybrid Type I, referring to a single
+      stream of interest, and Hybrid Type II, referring to two or more
+      streams of interest.
 
-   This document defines the term In-Packet OAM as a more specific and
-   narrowly scoped instance within the broader category of Hybrid OAM.
+   This document defines the term In-Data-Packet OAM as a more specific
+   and narrowly scoped instance within the broader category of Hybrid
+   OAM.
 
-   In-Packet OAM:
+   In-Data-Packet OAM:
       The OAM information is carried in the packets that also carry the
       data traffic.  This is a specific case of Hybrid OAM.  It was
       sometimes referred to as "in-band".
 
-   The MPLS echo request/reply messages [RFC8029] are an example of
-   "Active OAM", since they are described as "An MPLS echo request/reply
-   is a (possibly MPLS-labeled) IPv4 or IPv6 UDP packet".
+   The following examples illustrate the terms Active, Passive, Hybrid,
+   and In-Data-Packet OAM:
+
+   *  The MPLS echo request/reply messages [RFC8029] are an example of
+      "Active OAM", since they are described as "An MPLS echo request/
+      reply is a (possibly MPLS-labeled) IPv4 or IPv6 UDP packet".
+
+   *  Monitoring a packet stream by maintaining counters for the packets
+      within the stream is an example of "Passive OAM".
 
 
 
 
-
-Pignataro, et al.        Expires 3 January 2026                 [Page 4]
+Pignataro, et al.        Expires 31 January 2026                [Page 4]
 
 Internet-Draft             Characterizing OAM                  July 2025
 
 
-   IOAM [RFC9197] is an example of "Hybrid OAM" that is also "In-Packet
-   OAM", given that it: '...records OAM information within the packet
-   while the packet traverses a particular network domain.  The term "in
-   situ" refers to the fact that the OAM data is added to the data
-   packets rather than being sent within packets specifically dedicated
-   to OAM.'  Another example of In-Packet OAM is Alternate Marking
-   [RFC9341], in which a small number of bits in the packet header is
-   used for marking a subset of packets in a flow.
+   *  IOAM [RFC9197] is an example of "Hybrid OAM" that is also "In-
+      Data-Packet OAM", given that it: '...records OAM information
+      within the packet while the packet traverses a particular network
+      domain.  The term "in situ" refers to the fact that the OAM data
+      is added to the data packets rather than being sent within packets
+      specifically dedicated to OAM.'
 
-   An example of "Hybrid OAM" which is not classified as "In-Packet OAM"
-   is Direct loss measurement [RFC6374].
+   *  Another example of "Hybrid OAM" that is also "In-Data-Packet OAM"
+      is Alternate Marking [RFC9341], in which a small number of bits in
+      the packet header is used for marking a subset of packets in a
+      flow.
 
-   Initially, "In situ OAM" [RFC9197] was also referred to as "In-band
-   OAM", but was renamed due to the overloaded meaning of "In-band OAM".
-   Further, [RFC9232] also intertwines the terms "in-band" with "in
-   situ", though [I-D.song-opsawg-ifit-framework] settled on using "in
-   Situ".  Other similar uses, including [P4-INT-2.1] and
-   [I-D.kumar-ippm-ifa], still use variations of "in-band", "in band",
-   or "inband".
+   *  An example of "Hybrid OAM" which is not classified as "In-Data-
+      Packet OAM" is Direct loss measurement [RFC6374], in which user
+      packets are not modified by the protocol.  Instead, OAM packets
+      are used to exchange information about user packet counters,
+      allowing for packet loss computation.
+
+   *  Another example of "Hybrid OAM" which is not "In-Data-Packet OAM"
+      is the case where a packet stream is (actively) generated while an
+      existing stream of interest is (passively) observed.  This example
+      was introduced in [RFC7799] as a Hybrid method.
 
 3.2.  Path Followed OAM
 
@@ -268,16 +271,13 @@ Internet-Draft             Characterizing OAM                  July 2025
    An example of "Path-Congruent OAM" is the Virtual Circuit
    Connectivity Verification (VCCV), described is [RFC5085] as "The VCCV
    message travels in-band with the Session and follows the exact same
-   path as the user data for the session".  Thus, the term "in-band" in
-   [RFC5085] refers to using the same path as the user data.  This term
-   is also used in Section 2 of [RFC6669] with the same meaning, and the
-   word "congruent" is mentioned as synonymous.
+   path as the user data for the session".  The term "congruent" also
+   appears in [RFC6669] in the context of path sharing.
 
 
 
 
-
-Pignataro, et al.        Expires 3 January 2026                 [Page 5]
+Pignataro, et al.        Expires 31 January 2026                [Page 5]
 
 Internet-Draft             Characterizing OAM                  July 2025
 
@@ -314,13 +314,7 @@ Internet-Draft             Characterizing OAM                  July 2025
    [RFC9551] in the context of DetNet OAM: "it traverses the same set of
    links and interfaces receiving the same QoS and Packet Replication,
    Elimination, and Ordering Functions (PREOF) treatment as the
-   monitored DetNet flow".  This is classified in [RFC9551] as "In-band
-   OAM".  Similarly, the property of "Different-Forwarding-Treatment
-   OAM" can be found in the following definition in [RFC9551]: "Out-of-
-   band OAM: an active OAM method whose path through the DetNet domain
-   may not be topologically identical to the path of the monitored
-   DetNet flow, its test packets may receive different QoS and/or PREOF
-   treatment, or both."  [I-D.ietf-raw-architecture] uses similar text.
+   monitored DetNet flow".
 
 3.4.  Using Multiple Criteria
 
@@ -329,22 +323,20 @@ Internet-Draft             Characterizing OAM                  July 2025
    all criteria are applicable to all OAM protocols, and not all
    combinations are necessarily possible.
 
-
-
-
-
-Pignataro, et al.        Expires 3 January 2026                 [Page 6]
-
-Internet-Draft             Characterizing OAM                  July 2025
-
-
    When defining a new OAM protocol or analyzing an existing one, it is
    recommended to explicitly consider which of these criteria are
    applicable and to describe the protocol accordingly.  As a first
    step, all OAM mechanisms can be classified according to the first
-   criterion, as Active, Passive, or Hybrid/In-Packet.  Further
+   criterion, as Active, Passive, or Hybrid/In-Data-Packet.  Further
    classification according to the other two criteria should be
    considered on a case-by-case basis.
+
+
+
+Pignataro, et al.        Expires 31 January 2026                [Page 6]
+
+Internet-Draft             Characterizing OAM                  July 2025
+
 
    In some cases, certain criteria are not relevant, or not all
    combinations are possible.  For example:
@@ -368,7 +360,7 @@ Internet-Draft             Characterizing OAM                  July 2025
       Treatment.
 
    *  When IOAM [RFC9197] is incorporated in data packets it can be
-      classified as In-Packet, Path-Congruent and Equal-Forwarding-
+      classified as In-Data-Packet, Path-Congruent and Equal-Forwarding-
       Treatment.
 
    *  VCCV [RFC5085], as discussed above, is classified as Active, Path-
@@ -383,13 +375,21 @@ Internet-Draft             Characterizing OAM                  July 2025
       the inferred mode, it is Path-Congruent, and can be either Equal-
       or Different-Forwarding-Treatment OAM.
 
+   In measurement protocols, accurate results depend on path congruence
+   and equal forwarding treatment.  In contrast, these properties are
+   not always required in other OAM protocols.  For example,
+   Bidirectional Forwarding Detection (BFD) control packets are often
+   sent with the highest priority, which means they do not adhere to the
+   equal forwarding treatment property.
+
    This multi-dimensional classification enables a more precise and
    consistent understanding of OAM mechanisms.
 
 
 
 
-Pignataro, et al.        Expires 3 January 2026                 [Page 7]
+
+Pignataro, et al.        Expires 31 January 2026                [Page 7]
 
 Internet-Draft             Characterizing OAM                  July 2025
 
@@ -435,9 +435,9 @@ Internet-Draft             Characterizing OAM                  July 2025
    [I-D.ietf-raw-architecture]
               Thubert, P., "Reliable and Available Wireless
               Architecture", Work in Progress, Internet-Draft, draft-
-              ietf-raw-architecture-25, 10 June 2025,
+              ietf-raw-architecture-30, 25 July 2025,
               <https://datatracker.ietf.org/doc/html/draft-ietf-raw-
-              architecture-25>.
+              architecture-30>.
 
    [I-D.kumar-ippm-ifa]
               Kumar, J., Anubolu, S., Lemon, J., Manur, R., Holbrook,
@@ -445,7 +445,7 @@ Internet-Draft             Characterizing OAM                  July 2025
 
 
 
-Pignataro, et al.        Expires 3 January 2026                 [Page 8]
+Pignataro, et al.        Expires 31 January 2026                [Page 8]
 
 Internet-Draft             Characterizing OAM                  July 2025
 
@@ -501,7 +501,7 @@ Internet-Draft             Characterizing OAM                  July 2025
 
 
 
-Pignataro, et al.        Expires 3 January 2026                 [Page 9]
+Pignataro, et al.        Expires 31 January 2026                [Page 9]
 
 Internet-Draft             Characterizing OAM                  July 2025
 
@@ -533,6 +533,44 @@ Internet-Draft             Characterizing OAM                  July 2025
               Networking (DetNet)", RFC 9551, DOI 10.17487/RFC9551,
               March 2024, <https://www.rfc-editor.org/info/rfc9551>.
 
+Appendix A.  Examples of the Use of the Term In-Band
+
+   While several instances of the term "in-band" were discussed
+   throughout the document, this appendix provides additional examples.
+   These are intended to highlight the varying interpretations of the
+   term across different contexts.
+
+   Initially, "In situ OAM" [RFC9197] was also referred to as "In-band
+   OAM", but was renamed due to the overloaded meaning of "In-band OAM".
+   Further, [RFC9232] also intertwines the terms "in-band" with "in
+   situ", though [I-D.song-opsawg-ifit-framework] settled on using "in
+   Situ".  Other similar uses, including [P4-INT-2.1] and
+   [I-D.kumar-ippm-ifa], still use variations of "in-band", "in band",
+   or "inband".
+
+   The term "in-band" in [RFC5085] refers to using the same path as the
+   user data.  This term is also used in Section 2 of [RFC6669] with the
+   same meaning.
+
+
+
+
+
+
+Pignataro, et al.        Expires 31 January 2026               [Page 10]
+
+Internet-Draft             Characterizing OAM                  July 2025
+
+
+   The property of "Equal-Forwarding-Treatment" is referred to in
+   [RFC9551] as "In-band OAM".  Similarly, the property of "Different-
+   Forwarding-Treatment OAM" can be found in the following definition in
+   [RFC9551]: "Out-of-band OAM: an active OAM method whose path through
+   the DetNet domain may not be topologically identical to the path of
+   the monitored DetNet flow, its test packets may receive different QoS
+   and/or PREOF treatment, or both."  [I-D.ietf-raw-architecture] uses
+   similar text.
+
 Authors' Addresses
 
    Carlos Pignataro
@@ -557,4 +595,22 @@ Authors' Addresses
 
 
 
-Pignataro, et al.        Expires 3 January 2026                [Page 10]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Pignataro, et al.        Expires 31 January 2026               [Page 11]

--- a/draft-ietf-opsawg-oam-characterization.xml
+++ b/draft-ietf-opsawg-oam-characterization.xml
@@ -24,7 +24,7 @@
 <?rfc subcompact="no" ?>
 <?rfc symrefs="yes"?>
 <rfc category="bcp" consensus="true"
-     docName="draft-ietf-opsawg-oam-characterization-09" ipr="trust200902"
+     docName="draft-ietf-opsawg-oam-characterization-10" ipr="trust200902"
      submissionType="IETF" updates="6291">
   <?xml-stylesheet type='text/xsl' href='rfc2629.xslt' ?>
 
@@ -148,7 +148,7 @@
       networks (PSNs) which do not have a "band" per se, and, in fact, have
       multiple "somethings" that OAM traffic can be carried within or outside.
       A frequently encountered case is the use of "in-band" to mean either
-      In-Packet or on-path.</t>
+      In-Data-Packet or on-path.</t>
 
       <t>Within the IETF, the terms "in-band" and "out-of-band" cannot be
       reliably understood consistently and unambiguously. Context-specific
@@ -185,15 +185,17 @@
       mode; whether it follows the same path as data traffic; and whether it 
       receives the same treatment as data traffic.</t>
 
-      <section title="Active, Passive, Hybrid, and In-Packet OAM">
+      <section title="Active, Passive, Hybrid, and In-Data-Packet OAM">
         <t><xref target="RFC7799"/> provides clear definitions for active and
         passive performance assessment, enabling the construction of metrics
         and methods to be described as either "Active" or "Passive". Even
         though <xref target="RFC7799"/> does not explicitly use these terms as
         modifiers of "OAM", they are widely used in practice and are included
         here for clarity. The terms "Active", "Passive" and "Hybrid", as
-        described below, are consistent with <xref target="RFC7799"/>. <list
-            style="hanging">
+        described below, are consistent with <xref target="RFC7799"/>. This
+        document does not update or change the terms of 
+        <xref target="RFC7799"/>. 
+          <list style="hanging">
             <t hangText="Active OAM:"><br/> Depends on dedicated OAM
             packets.</t>
 
@@ -202,63 +204,66 @@
             dedicated OAM packets.</t>
 
             <t hangText="Hybrid OAM:"><br/> Uses augmentation or modification
-            of the packet stream. Examples of protocols classified as "Hybrid
-            OAM" include Alternate Marking <xref target="RFC9341"/>, In situ 
-            OAM (IOAM) <xref target="RFC9197"/>, and MPLS Loss Measurement 
-            <xref target="RFC6374"/>. Hybrid OAM can be implemented by
-            piggybacking OAM-related information onto data packets, as
-            described in <xref target="RFC9197"/>, or by utilizing reserved
-            fields in the packet header or specific values of existing header
-            fields, as proposed in <xref target="RFC9341"/>. Direct loss
-            measurment <xref target="RFC6374"/> is an example of "Hybrid OAM"
-            in which user packets are not modified by the protocol. Instead,
-            OAM packets are used to exchange information about user packet
-            counters, allowing for packet loss computation.</t>
+            of the packet stream. <xref target="RFC7799"/> makes a distinction
+            between Hybrid Type I, referring to a single stream of interest,
+            and Hybrid Type II, referring to two or more streams of interest.</t> 
           </list></t>
 
-        <t>This document defines the term In-Packet OAM as a more specific and
+        <t>This document defines the term In-Data-Packet OAM as a more specific and
         narrowly scoped instance within the broader category of Hybrid
         OAM.</t>
 
         <t>
           <list style="hanging">
-            <t hangText="In-Packet OAM:"><br/>The OAM information is carried
+            <t hangText="In-Data-Packet OAM:"><br/>The OAM information is carried
             in the packets that also carry the data traffic. This is a 
             specific case of Hybrid OAM. It was sometimes referred to as 
             "in-band".</t>
           </list>
         </t>
 
-        <t>The MPLS echo request/reply messages <xref target="RFC8029"/> are
-        an example of "Active OAM", since they are described as "An MPLS echo
-        request/reply is a (possibly MPLS-labeled) IPv4 or IPv6 UDP
-        packet".</t>
+        <t>The following examples illustrate the terms Active, Passive, 
+        Hybrid, and In-Data-Packet OAM:</t>
 
-        <t>IOAM <xref target="RFC9197"/> is an example of "Hybrid OAM"
-        that is also "In-Packet OAM", given that it: '...records OAM
-        information within the packet while the packet traverses a particular
-        network domain. The term "in situ" refers to the fact that the OAM
-        data is added to the data packets rather than being sent within
-        packets specifically dedicated to OAM.' Another example of In-Packet
-        OAM is Alternate Marking <xref target="RFC9341"/>, in which a small 
-        number of bits in the packet header is used for marking a subset of 
-        packets in a flow.</t>
+        <t>
+          <list style="symbols">
+            <t>The MPLS echo request/reply messages <xref target="RFC8029"/> are
+            an example of "Active OAM", since they are described as "An MPLS echo
+            request/reply is a (possibly MPLS-labeled) IPv4 or IPv6 UDP
+            packet".</t>
 
-        <t>An example of "Hybrid OAM" which is not classified as "In-Packet
-        OAM" is Direct loss measurement <xref target="RFC6374"/>.</t>
+            <t>Monitoring a packet stream by maintaining counters for the 
+            packets within the stream is an example of "Passive OAM".</t>
 
-        <t>Initially, "In situ OAM" <xref target="RFC9197"/> was also referred
-        to as "In-band OAM", but was renamed due to the overloaded meaning of
-        "In-band OAM". Further, <xref target="RFC9232"/> also intertwines the
-        terms "in-band" with "in situ", though <xref
-        target="I-D.song-opsawg-ifit-framework"/> settled on using "in Situ".
-        Other similar uses, including <xref target="P4-INT-2.1"/> and <xref
-        target="I-D.kumar-ippm-ifa"/>, still use variations of "in-band", "in
-        band", or "inband".</t>
+           <t>IOAM <xref target="RFC9197"/> is an example of "Hybrid OAM"
+           that is also "In-Data-Packet OAM", given that it: '...records OAM
+           information within the packet while the packet traverses a particular
+           network domain. The term "in situ" refers to the fact that the OAM
+           data is added to the data packets rather than being sent within
+           packets specifically dedicated to OAM.'</t>
+
+           <t>Another example of "Hybrid OAM" that is also "In-Data-Packet 
+           OAM" is Alternate Marking <xref target="RFC9341"/>, in which a small 
+           number of bits in the packet header is used for marking a subset of 
+           packets in a flow.</t>
+
+           <t>An example of "Hybrid OAM" which is not classified as "In-Data-Packet
+           OAM" is Direct loss measurement <xref target="RFC6374"/>,            
+           in which user packets are not modified by the protocol. Instead,
+           OAM packets are used to exchange information about user packet
+           counters, allowing for packet loss computation.</t>
+
+           <t>Another example of "Hybrid OAM" which is not "In-Data-Packet OAM"
+           is the case where a packet stream is (actively) generated while 
+           an existing stream of interest is (passively) observed. This
+           example was introduced in <xref target="RFC7799"/> as a Hybrid 
+           method.</t>
+          </list>
+        </t>
 
         <!--
 <t>
-  It is noteworthy that In-Packet OAM cannot be Non-Path-Congruent OAM.
+  It is noteworthy that In-Data-Packet OAM cannot be Non-Path-Congruent OAM.
 </t>
 -->
       </section>
@@ -289,10 +294,8 @@
         Connectivity Verification (VCCV), described is <xref
         target="RFC5085"/> as "The VCCV message travels in-band with the
         Session and follows the exact same path as the user data for the
-        session". Thus, the term "in-band" in <xref target="RFC5085"/> refers
-        to using the same path as the user data. This term is also used in
-        Section 2 of <xref target="RFC6669"/> with the same meaning, and the
-        word "congruent" is mentioned as synonymous.</t>
+        session". The term "congruent" also appears in 
+        <xref target="RFC6669"/> in the context of path sharing.</t>
       </section>
 
       <section title="Packet Forwarding Treatment OAM">
@@ -329,16 +332,10 @@
         <xref target="RFC9551"/> in the context of DetNet OAM: "it traverses 
         the same set of links and interfaces receiving the same QoS and 
         Packet Replication, Elimination, and Ordering Functions (PREOF) 
-        treatment as the monitored DetNet flow". This is classified in 
-        <xref target="RFC9551"/> as "In-band OAM". Similarly, the property of 
-        "Different-Forwarding-Treatment OAM" can be found in the following 
-        definition in <xref target="RFC9551"/>: "Out-of-band OAM: an active 
-        OAM method whose path through the DetNet domain may not be 
-        topologically identical to the path of the monitored DetNet flow, its 
-        test packets may receive different QoS and/or PREOF treatment, or 
-        both." <xref target="I-D.ietf-raw-architecture"/> uses similar text.
+        treatment as the monitored DetNet flow". 
         </t>
       </section>
+
 
       <section title="Using Multiple Criteria">
         <t>OAM protocols and tools can be classified according to the three
@@ -350,7 +347,7 @@
         is recommended to explicitly consider which of these criteria are
         applicable and to describe the protocol accordingly. As a first step,
         all OAM mechanisms can be classified according to the first criterion,
-        as Active, Passive, or Hybrid/In-Packet. Further classification
+        as Active, Passive, or Hybrid/In-Data-Packet. Further classification
         according to the other two criteria should be considered on a 
         case-by-case basis.</t>
 
@@ -383,7 +380,7 @@
             as Different-Forwarding-Treatment.</t>
 
             <t>When IOAM <xref target="RFC9197"/> is incorporated in data
-            packets it can be classified as In-Packet, Path-Congruent and
+            packets it can be classified as In-Data-Packet, Path-Congruent and
             Equal-Forwarding-Treatment.</t>
 
             <t>VCCV <xref target="RFC5085"/>, as discussed above, is
@@ -401,6 +398,13 @@
             Different-Forwarding-Treatment OAM.</t>
           </list>
         </t>
+
+        <t>In measurement protocols, accurate results depend on path 
+        congruence and equal forwarding treatment. In contrast, these 
+        properties are not always required in other OAM protocols. For 
+        example, Bidirectional Forwarding Detection (BFD) control packets 
+        are often sent with the highest priority, which means they do 
+        not adhere to the equal forwarding treatment property.</t>
 
         <t>This multi-dimensional classification enables a more precise and
         consistent understanding of OAM mechanisms.</t>
@@ -481,5 +485,36 @@
         </front>
       </reference>
     </references>
+
+    <section anchor="appendix" title="Examples of the Use of the Term In-Band">
+      <t>While several instances of the term "in-band" were discussed 
+      throughout the document, this appendix provides additional examples. 
+      These are intended to highlight the varying interpretations of the term 
+      across different contexts.</t>
+
+      <t>Initially, "In situ OAM" <xref target="RFC9197"/> was also referred
+      to as "In-band OAM", but was renamed due to the overloaded meaning of
+      "In-band OAM". Further, <xref target="RFC9232"/> also intertwines the
+      terms "in-band" with "in situ", though <xref
+      target="I-D.song-opsawg-ifit-framework"/> settled on using "in Situ".
+      Other similar uses, including <xref target="P4-INT-2.1"/> and <xref
+      target="I-D.kumar-ippm-ifa"/>, still use variations of "in-band", "in
+      band", or "inband".</t>
+
+      <t>The term "in-band" in <xref target="RFC5085"/> refers
+      to using the same path as the user data. This term is also used in
+      Section 2 of <xref target="RFC6669"/> with the same meaning.</t> 
+
+      <t>The property of "Equal-Forwarding-Treatment" is referred to in 
+      <xref target="RFC9551"/> as "In-band OAM". Similarly, the property of 
+      "Different-Forwarding-Treatment OAM" can be found in the following 
+      definition in <xref target="RFC9551"/>: "Out-of-band OAM: an active 
+      OAM method whose path through the DetNet domain may not be 
+      topologically identical to the path of the monitored DetNet flow, its 
+      test packets may receive different QoS and/or PREOF treatment, or 
+      both." <xref target="I-D.ietf-raw-architecture"/> uses similar text.
+      </t>
+    </section>
+
   </back>
 </rfc>


### PR DESCRIPTION
Main changes since 09:
- Based on feedback from IETF 123.
- "In-Packet" changed to "In-Data-Packet".
- Moved most of the "in-band" examples to appendix.
- Added clarification about measurement protocols vs. other OAM protocols.
- Clarified the "Hybrid" definition and the overlap with "In-Data-Packet".
- Added clearer examples of Active/Passive/Hybrid/In-Data-Packet, specifically explaining the difference between Hybrid and In-Data-Packet.